### PR TITLE
(GH12) Update systemd tmpfiles

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -91,15 +91,18 @@ class puppet_metrics_dashboard::install(
     require => Package['influxdb'],
   }
 
-  # Hacky workaround for #12
-  if $facts['os']['family'] == 'RedHat' and !defined(File['/var/run/grafana']) {
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
 
-    file { '/var/run/grafana' :
-      ensure  => directory,
-      owner   => 'grafana',
-      group   => 'grafana',
+    file { '/usr/lib/tmpfiles.d/grafana.conf' :
+      ensure  => file,
+      content => 'd /var/run/grafana 0755 grafana grafana',
       require => Package['grafana'],
       before  => Service['grafana-server'],
+      notify  => Exec['Create Systemd Temp Files'],
+    }
+    exec { 'Create Systemd Temp Files':
+      command     => '/bin/systemd-tmpfiles --create',
+      refreshonly => true,
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,9 @@ describe 'puppet_metrics_dashboard' do
         osfamily: 'RedHat',
         os: {
           family: 'RedHat',
+          release: {
+            major: '7',
+          },
         },
         operatingsystem: 'RedHat',
         pe_server_version: '2017.2',

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -7,6 +7,9 @@ describe 'puppet_metrics_dashboard::install' do
         osfamily: 'RedHat',
         os: {
           family: 'RedHat',
+          release: {
+             major: '7',
+          },
         },
         operatingsystem: 'RedHat',
         pe_server_version: '2017.2',


### PR DESCRIPTION
Prior to this commit we had a workaround to create a directory for the
PID file of grafana. This commit removes the workaround and adds a
method for creating the var run directory at boot. This is to address issue #12 where the service cannot start on RHEL 7 after a reboot. 