### PR TITLE
(maint) Update to PDK 1.6.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
     repositories:
       stdlib:
         repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
-        ref: 4.3.2
+        ref: 4.25.1
       apt:
         repo: https://github.com/puppetlabs/puppetlabs-apt.git
         ref: 4.3.0

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,7 +5,7 @@ appveyor.yml:
   delete: true
 
 .travis.yml:
-  bundle_args: --without system_tests
+  bundler_args: -----without system_tests
   docker_sets:
     - set: docker/centos-7
       options:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   - bundle -v
 script:
   - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests
+bundler_args: 
 rvm:
-  - 2.4.1
+  - 2.4.4
 env:
   global:
     - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
@@ -22,15 +22,15 @@ matrix:
   include:
     -
       dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/centos-7
-      rvm: 2.4.1
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/centos-7 BEAKER_TESTMODE=apply
+      rvm: 2.4.4
       script: bundle exec rake beaker
       services: docker
       sudo: required
     -
       dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-16.04
-      rvm: 2.4.1
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-16.04 BEAKER_TESTMODE=apply
+      rvm: 2.4.4
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -43,9 +43,9 @@ matrix:
       rvm: 2.1.9
 branches:
   only:
-    - master
-    - /^v\d/
-    - /.*/
+    - master 
+    - /^v\d/ 
+    - /.*/ 
 notifications:
   email: false
 deploy:

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
       "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.6.0 (heads/master-0-ga339b38)",
+  "pdk-version": "1.6.1 (v1.6.1-0-g26a4f2f)",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "heads/master-0-gc87eee3"
+  "template-ref": "heads/master-0-g0657063"
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -8,7 +8,7 @@ describe 'puppet_metrics_dashboard::install' do
         os: {
           family: 'RedHat',
           release: {
-             major: '7',
+            major: '7',
           },
         },
         operatingsystem: 'RedHat',


### PR DESCRIPTION
Prior to this commit the gems were not correctly being installed and
there was a rubocop error. This commit updates the PDK to 1.6.1 to
rectify the issue and install the gems correctly.