### PR TITLE
(maint) Update to PDK 1.7.0 and Beaker 4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,4 +10,5 @@ fixtures:
         ref: 4.3.0
       grafana: 
         repo: https://github.com/voxpupuli/puppet-grafana.git
+        ref: v4.5.0
     forge_modules:

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,16 +23,15 @@ Gemfile:
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         platforms: ruby
       - gem: beaker
-        version: '~> 3.13'
-        from_env: BEAKER_VERSION
+        version: '~> 4'
+      - gem: beaker-puppet
+        version: '~> 1.0'
       - gem: beaker-abs
-        from_env: BEAKER_ABS_VERSION
         version: '~> 0.1'
       - gem: beaker-pe
-      - gem: beaker-hostgenerator
-        from_env: BEAKER_HOSTGENERATOR_VERSION
       - gem: beaker-rspec
-        from_env: BEAKER_RSPEC_VERSION
+      - gem: beaker-docker
+      - gem: beaker-vagrant
 
 spec/spec_helper.rb:
   mock_with: ':rspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ matrix:
       rvm: 2.1.9
 branches:
   only:
-    - master 
-    - /^v\d/ 
-    - /.*/ 
+    - master
+    - /^v\d/
+    - /.*/
 notifications:
   email: false
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -36,12 +36,14 @@ group :development do
   gem "puppet-strings", '~> 2.0.0',                    require: false
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
-  gem "beaker-pe",                                                               require: false
-  gem "beaker-hostgenerator"
-  gem "beaker-rspec"
+  gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "beaker", '~> 4',                               require: false
+  gem "beaker-puppet", '~> 1.0',                      require: false
+  gem "beaker-abs", '~> 0.1',                         require: false
+  gem "beaker-pe",                                    require: false
+  gem "beaker-rspec",                                 require: false
+  gem "beaker-docker",                                require: false
+  gem "beaker-vagrant",                               require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
       "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.6.1 (v1.6.1-0-g26a4f2f)",
+  "pdk-version": "1.7.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "heads/master-0-g0657063"
+  "template-ref": "1.7.0-0-g57412ed"
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,7 @@
 require 'puppet'
 require 'beaker-rspec'
+require 'beaker-puppet'
+require 'beaker-pe'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 


### PR DESCRIPTION
Prior to this commit, the repo was on PDK 1.6.1 and there was no top
limit to the beaker gem. Since Beaker 4 was a breaking change, it needed
to be configured to enable the spec tests moving forward. Otherwise, we
would have encountered random failures in the CI unrelated to the changes
in PRs. This commit updates the repo to use Beaker 4.