### PR TITLE
add postgres metrics, initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ By default, this will create a set of certificates in `/etc/grafana` that are ba
 
 _Note:_ Enabling SSL on Grafana will not allow for running on privileged ports such as `443`. To enable this capability you can use the suggestions documented in [this Grafana documentation](http://docs.grafana.org/installation/configuration/#http-port)
 
+### Collect metrics from postgres
+
+To allow telegraf to connect to postgres, apply the included profile class to the postgres host:
+
+```
+include puppet_metrics_dashboard::profile::postgres
+```
+
 ### Other possibilities
 
 Configure the passwords for the InfluxDB and Grafana administrator users and enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components.

--- a/manifests/certs.pp
+++ b/manifests/certs.pp
@@ -1,0 +1,25 @@
+class puppet_metrics_dashboard::certs{
+  
+  $ssl_dir        = $::settings::ssldir 
+  $cert_dir       = "/etc/telegraf"
+  $client_pem_key = "${ssl_dir}/private_keys/${fqdn}.pem"
+  $client_cert    = "${ssl_dir}/certs/${fqdn}.pem"
+
+  File {
+    owner   => telegraf,
+    group   => telegraf,
+    mode    => '0400',
+  }
+
+  file { "${cert_dir}/${fqdn}.private_key.pem":
+    source => $client_pem_key,
+  }
+
+  file { "${cert_dir}/${fqdn}.public_key.pem":
+    source => "${ssl_dir}/certs/${fqdn}.pem",
+  }
+
+  file { "${cert_dir}/ca.pem":
+    source => "${ssl_dir}/certs/ca.pem",
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,9 @@
 #   An array of PuppetDB servers to collect metrics from. Defaults to `["$::settings::certname"]`
 #   A list of PuppetDB servers that will be configured for telegraf to query.
 #
+# @param postgres_host
+#   String that specifies a postgres instance to monitor.  Defaults to $::settings::certname
+#
 # @param use_dashboard_ssl
 #   Whether to enable SSL on Grafana.
 #   Valid values are `true`, `false`. Defaults to `false`
@@ -166,7 +169,8 @@ class puppet_metrics_dashboard (
   Boolean $configure_telegraf             =  $puppet_metrics_dashboard::params::configure_telegraf,
   Boolean $consume_graphite               =  $puppet_metrics_dashboard::params::consume_graphite,
   Array[String] $master_list              =  $puppet_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list
+  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list,
+  String $postgres_host                   =  $puppet_metrics_dashboard::params::postgres_host,
   ) inherits puppet_metrics_dashboard::params {
 
     class { 'puppet_metrics_dashboard::install':
@@ -190,5 +194,6 @@ class puppet_metrics_dashboard (
     consume_graphite          =>  $consume_graphite,
     master_list               =>  $master_list,
     puppetdb_list             =>  $puppetdb_list,
+    postgres_host             =>  $postgres_host,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,8 +12,8 @@ class puppet_metrics_dashboard::params {
   $manage_repos           =  true
   $overwrite_dashboards   =  true
   $use_dashboard_ssl      =  false
-  $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"
-  $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"
+  $dashboard_cert_file    = "/etc/grafana/${fqdn}.public_key.pem"
+  $dashboard_cert_key     = "/etc/grafana/${fqdn}.private_key.pem"
   $influxdb_database_name =  ['telegraf']
   $grafana_version        =  '5.1.4'
   $grafana_http_port      =  3000
@@ -28,6 +28,7 @@ class puppet_metrics_dashboard::params {
   $configure_telegraf     =  true
   $master_list            =  [$::settings::certname]
   $puppetdb_list          =  [$::settings::certname]
+  $postgres_host          =  $::settings::certname
 
   $overwrite_dashboards_file = '/opt/puppetlabs/puppet/cache/state/overwrite_dashboards_disabled'
 

--- a/manifests/profile/postgres.pp
+++ b/manifests/profile/postgres.pp
@@ -1,0 +1,31 @@
+class puppet_metrics_dashboard::profile::postgres (
+) inherits puppet_enterprise::profile::database {
+
+  ## Potential problem: we really want only one certname out of this
+  $grafana_host = puppetdb_query('resources[certname] {
+                        type = "Class" and
+                        title = "Puppet_metrics_dashboard" and
+                        nodes { 
+                          deactivated is null and
+                          expired is null
+                        }
+                      }')[0]['certname']
+
+  pe_postgresql::server::role { 'telegraf':}
+
+  pe_postgresql::server::database_grant { 'telegraf':
+    privilege => 'CONNECT',
+    db        => 'pe-puppetdb',
+    role      => 'telegraf',
+  }
+
+  puppet_enterprise::pg::cert_whitelist_entry { "allow-telegraf-access":
+    user                          => 'telegraf',
+    database                      => 'pe-puppetdb',
+    allowed_client_certname       => $grafana_host,
+    pg_ident_conf_path            => $pg_ident_conf_path,
+    ip_mask_allow_all_users_ssl   => $ip_mask_allow_all_users_ssl,
+    ipv6_mask_allow_all_users_ssl => $ipv6_mask_allow_all_users_ssl,
+  }
+
+}

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -5,6 +5,7 @@ class puppet_metrics_dashboard::telegraf (
   String $influx_db_service_name      =  $puppet_metrics_dashboard::install::influx_db_service_name,
   Array[String] $master_list          =  $puppet_metrics_dashboard::install::master_list,
   Array[String] $puppetdb_list        =  $puppet_metrics_dashboard::install::puppetdb_list,
+  String $postgres_host               =  $puppet_metrics_dashboard::install::postgres_host,
   Array[String] $additional_metrics   = [],
   ) {
 
@@ -191,9 +192,10 @@ class puppet_metrics_dashboard::telegraf (
       group   => 0,
       content => epp('puppet_metrics_dashboard/telegraf.conf.epp',
         {
-          puppetdb_metrics => $puppetdb_metrics,
-          master_list      => $master_list,
-          puppetdb_list    => $puppetdb_list,
+          puppetdb_metrics  => $puppetdb_metrics,
+          master_list       => $master_list,
+          puppetdb_list     => $puppetdb_list,
+          postgres_host     => $postgres_host,
         }),
       notify  => Service['telegraf'],
       require => Package['telegraf'],

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -68,3 +68,31 @@
 <% } -%>
 <% } -%>
 <%# -%>
+
+<% if $postgres_host {-%>
+
+[[inputs.postgresql_extensible]]
+  address = "postgres://telegraf@<%= $postgres_host %>/pe-puppetdb?sslmode=require&sslkey=/etc/telegraf/grafana-server.platform9.puppet.net.private_key.pem&sslcert=/etc/telegraf/grafana-server.platform9.puppet.net.public_key.pem&sslrootcert=/etc/telegraf/ca.pem"
+  databases = ["pe-puppetdb","pe-rbac","pe-activity","pe-classifier"]
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="SELECT * FROM pg_stat_database"
+    version=901
+    withdbname=false
+    tagvalue=""
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="SELECT relname as s_table, pg_relation_size(relid) As size FROM pg_catalog.pg_statio_user_tables ORDER BY pg_total_relation_size(relid) DESC"
+    version=901
+    withdbname=false
+    tagvalue="s_table"
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="select relname as v_table, autovacuum_count, vacuum_count, n_live_tup, n_dead_tup from pg_stat_user_tables"
+    version=901
+    withdbname=false
+    tagvalue="v_table"
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="select relname as io_table, heap_blks_read, heap_blks_hit, idx_blks_read, idx_blks_hit, toast_blks_read, toast_blks_hit, tidx_blks_read, tidx_blks_hit from pg_statio_user_tables"
+    version=901
+    withdbname=false
+    tagvalue="io_table"
+
+<% } -%>


### PR DESCRIPTION
This commit will add the ability to collect and display metrics from postgres.

We'll need to ensure that telegraf is at v1.10.0 (unreleased) in order for this to work