### PR TITLE
Add params, separate configs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,6 +8,9 @@ fixtures:
       apt:
         repo: https://github.com/puppetlabs/puppetlabs-apt.git
         ref: 4.3.0
+      inifile:
+        repo: https://github.com/puppetlabs/puppetlabs-inifile.git
+        ref: 2.4.0
       grafana: 
         repo: https://github.com/voxpupuli/puppet-grafana.git
         ref: v4.5.0

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 1. [Description](#description)
 2. [Setup - The basics of getting started with puppet_metrics_dashboard](#setup)
-  * [What puppet_metrics_dashboard affects](#what-puppet_metrics_dashboard-affects)
-  * [Setup requirements](#setup-requirements)
+  * [Upgrade note](#upgrade-note)
   * [Beginning with puppet_metrics_dashboard](#beginning-with-puppet_metrics_dashboard)
 3. [Usage - Configuration options and additional functionality](#usage)
 4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
@@ -18,11 +17,21 @@ This module is used to configure grafana, telegraf, and influxdb to consume metr
 
 You have the option of getting metrics from any or all of three of these methods:
 
-* Through Archive files from the [npwalker/pe_metric_curl_cron_jobs](https://forge.puppet.com/npwalker/pe_metric_curl_cron_jobs) module
-* Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2017.3/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support)
+* Through Archive files from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
+* Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2019.0/getting_started_with_graphite.html#task-7933)
 * Through telegraf, which polls several of Puppet's metrics endpoints
 
 ## Setup
+
+### Upgrade note
+
+Previous versions of this module put several `[[inputs.httpjson]]` entries in
+`/etc/telegraf/telegraf.conf`. These entries should be removed now as all
+module-specific settings now reside in
+`/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf`. Telegraf will
+continue to work if you do not remove them, however, the old 
+`[[inputs.httpjson]]` will not be updated going forward.
+
 
 ### Beginning with puppet_metrics_dashboard
 
@@ -124,180 +133,6 @@ class { 'puppet_metrics_dashboard':
 
 **Note** This section is no longer maintained. Please see the REFERENCE.MD file for current listings. 
 
-### Classes
-
-#### Public classes
-
-* [`puppet_metrics_dashboard`](#puppet_metrics_dashboard): Installs and configures the Puppet Grafana dashboards and underlying connections.
-
-#### Private classes
-
-* [`puppet_metrics_dashboard::install`](#puppet_metrics_dashboardinstall): Installs and configures the Puppet Grafana dashboards and underlying connections.
-
-### Parameters
-
-#### puppet_metrics_dashboard
-
-##### add_dashboard_examples
-
-Whether to add the Grafana dashboard example dashboards for the configured InfluxDB databases.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`.
-
-*Note:* These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
-
-##### dashboard_cert_file
-
-The location of the Grafana certficiate.
-
-Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
-
-##### dashboard_cert_key
-
-The location of the Grafana private key.
-
-Defaults to `"/etc/grafana/${clientcert}_key.pem"`
-
-##### configure_telegraf
-
-Whether to configure the telegraf service.
-
-Valid values are `true`, `false`.
-
-Defaults to `true`
-
-This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
-
-_Note:_ This parameter enables `enable_telegraf` if set to true.
-
-##### consume_graphite
-
-Whether to enable the InfluxDB Graphite plugin.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`
-
-This parameter enables the Graphite plugin for InfluxDB to allow for injesting Graphite metrics. Ensure `influxdb_database_name` contains `graphite` when using this parameter.
-
-*Note:* If using Graphite metrics from the Puppet Master, this needs to be set to `true`.
-
-##### grafana_http_port
-
-The port to run Grafana on.
-
-Valid values are Integers from `1024` to `65536`.
-
-Defaults to `3000`
-
-The grafana port for the web interface. This should be a nonprivileged port (above 1024).
-
-_Note:_ Grafana will not run on privileged ports such as `443`. To enable this capability you can use the suggestions documented in [this Grafana documentation](http://docs.grafana.org/installation/configuration/#http-port)
-
-##### grafana_password
-
-The password for the Grafana admin user.
-
-Defaults to `'admin'`
-
-##### grafana_version
-
-The grafana version to install.
-
-Valid values are String versions of Grafana.
-
-Defaults to `'4.5.2'`
-
-##### influxdb_database_name
-
-An array of databases that should be created in InfluxDB.
-
-Valid values are 'puppet_metrics','telegraf', 'graphite', and any other string.
-
-Defaults to `['telegraf']`
-
-Each database in the array will be created in InfluxDB. 'puppet_metrics','telegraf', and 'graphite' are specially named and will be used with their associated metric collection method. Any other database name will be created, but not utilized with components in this module.
-
-##### influx_db_password
-
-The password for the InfluxDB admin user.
-
-Defaults to `'puppet'`
-
-##### enable_kapacitor
-
-Whether to install kapacitor.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`
-
-Install kapacitor. No configuration of kapacitor is included at this time.
-
-##### enable_chronograf
-
-Whether to install chronograf.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`
-
-Installs chronograf. No configuration of chronograf is included at this time.
-
-##### enable_telegraf
-
-Whether to install telegraf.
-
-Valid values are `true`, `false`.
-
-Defaults to `true`
-
-Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
-
-##### manage_repos
-
-Whether or not to setup yum / apt repositories for the dependent packages
-
-Valid values are `true`, `false`. 
-
-Defaults to `true`
-
-##### master_list
-
-An array of Puppet Master servers to collect metrics from.
-
-Defaults to `["$::settings::certname"]`
-
-A list of Puppet master servers that will be configured for telegraf to query.
-
-##### overwrite_dashboards
-
-Whether to overwrite the example Grafana dashboards.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`
-
-This paramater disables overwriting the example Grafana dashboards. It takes effect after the second Puppet run and popultes the `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
-
-##### puppetdb_list
-
-An array of PuppetDB servers to collect metrics from.
-
-Defaults to `["$::settings::certname"]`
-
-A list of PuppetDB servers that will be configured for telegraf to query.
-
-##### use_dashboard_ssl
-
-Whether to enable SSL on Grafana.
-
-Valid values are `true`, `false`.
-
-Defaults to `false`
-
 ## Limitations
 
 ### Repo failure for InfluxDB packages
@@ -316,3 +151,5 @@ yum install curl nss --disablerepo influxdb
 
 
 ## Development
+
+Please see CONTRIBUTING.md

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -244,10 +244,42 @@ Default value: $puppet_metrics_dashboard::params::enable_telegraf
 
 Data type: `Array[String]`
 
-An array of Puppet Master servers to collect metrics from. Defaults to `["$::settings::certname"]`
+An array of Puppet Master servers to collect metrics from. Defaults to `["$settings::certname"]`
 A list of Puppet master servers that will be configured for telegraf to query.
 
 Default value: $puppet_metrics_dashboard::params::master_list
+
+##### `influxdb_urls`
+
+Data type: `String`
+
+The string for telegraf's config defining where influxdb is
+
+Default value: $puppet_metrics_dashboard::params::influxdb_urls
+
+##### `telegraf_db_name`
+
+Data type: `String`
+
+The database in influxdb where telefraf metrics are stored
+
+Default value: $puppet_metrics_dashboard::params::telegraf_db_name
+
+##### `telegraf_agent_interval`
+
+Data type: `Integer[1]`
+
+How often the telefraf agent queries for metrics
+
+Default value: $puppet_metrics_dashboard::params::telegraf_agent_interval
+
+##### `http_response_timeout`
+
+Data type: `Integer[1]`
+
+How long to wait for the queries by telegraf to finish before giving up
+
+Default value: $puppet_metrics_dashboard::params::http_response_timeout
 
 ##### `overwrite_dashboards`
 
@@ -264,7 +296,7 @@ Default value: $puppet_metrics_dashboard::params::overwrite_dashboards
 
 Data type: `Array[String]`
 
-An array of PuppetDB servers to collect metrics from. Defaults to `["$::settings::certname"]`
+An array of PuppetDB servers to collect metrics from. Defaults to `["$settings::certname"]`
 A list of PuppetDB servers that will be configured for telegraf to query.
 
 Default value: $puppet_metrics_dashboard::params::puppetdb_list

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,8 +76,20 @@
 #   Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
 #
 # @param master_list
-#   An array of Puppet Master servers to collect metrics from. Defaults to `["$::settings::certname"]`
+#   An array of Puppet Master servers to collect metrics from. Defaults to `["$settings::certname"]`
 #   A list of Puppet master servers that will be configured for telegraf to query.
+#
+# @param influxdb_urls
+#   The string for telegraf's config defining where influxdb is
+#
+# @param telegraf_db_name
+#   The database in influxdb where telefraf metrics are stored
+#
+# @param telegraf_agent_interval
+#   How often the telefraf agent queries for metrics
+#
+# @param http_response_timeout
+#   How long to wait for the queries by telegraf to finish before giving up
 #
 # @param overwrite_dashboards
 #   Whether to overwrite the example Grafana dashboards.
@@ -86,7 +98,7 @@
 #   `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
 #
 # @param puppetdb_list
-#   An array of PuppetDB servers to collect metrics from. Defaults to `["$::settings::certname"]`
+#   An array of PuppetDB servers to collect metrics from. Defaults to `["$settings::certname"]`
 #   A list of PuppetDB servers that will be configured for telegraf to query.
 #
 # @param use_dashboard_ssl
@@ -166,7 +178,11 @@ class puppet_metrics_dashboard (
   Boolean $configure_telegraf             =  $puppet_metrics_dashboard::params::configure_telegraf,
   Boolean $consume_graphite               =  $puppet_metrics_dashboard::params::consume_graphite,
   Array[String] $master_list              =  $puppet_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list
+  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list,
+  String $influxdb_urls                   =  $puppet_metrics_dashboard::params::influxdb_urls,
+  String $telegraf_db_name                =  $puppet_metrics_dashboard::params::telegraf_db_name,
+  Integer[1] $telegraf_agent_interval     =  $puppet_metrics_dashboard::params::telegraf_agent_interval,
+  Integer[1] $http_response_timeout       =  $puppet_metrics_dashboard::params::http_response_timeout,
   ) inherits puppet_metrics_dashboard::params {
 
     class { 'puppet_metrics_dashboard::install':
@@ -190,5 +206,9 @@ class puppet_metrics_dashboard (
     consume_graphite          =>  $consume_graphite,
     master_list               =>  $master_list,
     puppetdb_list             =>  $puppetdb_list,
+    influxdb_urls             =>  $influxdb_urls,
+    telegraf_db_name          =>  $telegraf_db_name,
+    telegraf_agent_interval   =>  $telegraf_agent_interval,
+    http_response_timeout     =>  $http_response_timeout,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,11 @@ class puppet_metrics_dashboard::install(
   Boolean $configure_telegraf             =  $puppet_metrics_dashboard::params::configure_telegraf,
   Boolean $consume_graphite               =  $puppet_metrics_dashboard::params::consume_graphite,
   Array[String] $master_list              =  $puppet_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list
+  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list,
+  String $influxdb_urls                   =  $puppet_metrics_dashboard::params::influxdb_urls,
+  String $telegraf_db_name                =  $puppet_metrics_dashboard::params::telegraf_db_name,
+  Integer[1] $telegraf_agent_interval     =  $puppet_metrics_dashboard::params::telegraf_agent_interval,
+  Integer[1] $http_response_timeout       =  $puppet_metrics_dashboard::params::http_response_timeout,
 ) inherits puppet_metrics_dashboard::params {
 
   # Enable Telegraf if `configure_telegraf` is true.
@@ -129,10 +133,14 @@ class puppet_metrics_dashboard::install(
 
   if $_enable_telegraf {
     class { 'puppet_metrics_dashboard::telegraf':
-      configure_telegraf     => $configure_telegraf,
-      influx_db_service_name => $influx_db_service_name,
-      master_list            => $master_list,
-      puppetdb_list          => $puppetdb_list,
+      configure_telegraf      => $configure_telegraf,
+      influx_db_service_name  => $influx_db_service_name,
+      master_list             => $master_list,
+      puppetdb_list           => $puppetdb_list,
+      influxdb_urls           => $influxdb_urls,
+      telegraf_db_name        => $telegraf_db_name,
+      telegraf_agent_interval => $telegraf_agent_interval,
+      http_response_timeout   => $http_response_timeout,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,30 +8,34 @@
 class puppet_metrics_dashboard::params {
 
   # Default Installation parameters
-  $add_dashboard_examples =  false
-  $manage_repos           =  true
-  $overwrite_dashboards   =  true
-  $use_dashboard_ssl      =  false
-  $dashboard_cert_file    = "/etc/grafana/${clientcert}_cert.pem"
-  $dashboard_cert_key     = "/etc/grafana/${clientcert}_key.pem"
-  $influxdb_database_name =  ['telegraf']
-  $grafana_version        =  '5.1.4'
-  $grafana_http_port      =  3000
-  $influx_db_password     =  'puppet'
-  $grafana_password       =  'admin'
-  $consume_graphite       =  false
+  $add_dashboard_examples  =  false
+  $manage_repos            =  true
+  $overwrite_dashboards    =  true
+  $use_dashboard_ssl       =  false
+  $dashboard_cert_file     = "/etc/grafana/${clientcert}_cert.pem"
+  $dashboard_cert_key      = "/etc/grafana/${clientcert}_key.pem"
+  $influxdb_database_name  =  ['telegraf']
+  $grafana_version         =  '5.1.4'
+  $grafana_http_port       =  3000
+  $influx_db_password      =  'puppet'
+  $grafana_password        =  'admin'
+  $consume_graphite        =  false
   # Influxdb TICK stack
-  $enable_telegraf        =  true
-  $enable_kapacitor       =  false
-  $enable_chronograf      =  false
+  $enable_telegraf         =  true
+  $enable_kapacitor        =  false
+  $enable_chronograf       =  false
   # telegraf config
-  $configure_telegraf     =  true
-  $master_list            =  [$::settings::certname]
-  $puppetdb_list          =  [$::settings::certname]
+  $configure_telegraf      =  true
+  $master_list             =  [$settings::certname]
+  $puppetdb_list           =  [$settings::certname]
+  $influxdb_urls           =  "['http://localhost:8086']"
+  $telegraf_db_name        =  'telegraf'
+  $telegraf_agent_interval = 5
+  $http_response_timeout   = 5 # this is the default value for the HTTP JSON Input
 
   $overwrite_dashboards_file = '/opt/puppetlabs/puppet/cache/state/overwrite_dashboards_disabled'
 
-  case $::osfamily {
+  case $facts['os']['family'] {
 
     'RedHat': {
       $influx_db_service_name = 'influxdb'
@@ -40,7 +44,7 @@ class puppet_metrics_dashboard::params {
       $influx_db_service_name = 'influxd'
     }
     default: {
-      fail("${::osfamily} installation not supported")
+      fail("${facts['os']['family']} installation not supported")
     }
   }
 

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -5,7 +5,7 @@ class puppet_metrics_dashboard::repos (
   Boolean $manage_repos = $puppet_metrics_dashboard::install::manage_repos,
 ) {
 
-  case $::osfamily {
+  case $facts['os']['family'] {
 
     'RedHat': {
       if ( $manage_repos ){
@@ -33,8 +33,8 @@ class puppet_metrics_dashboard::repos (
 
     'Debian': {
 
-      $_operatingsystem = downcase($::facts['os']['name'])
-      $_oscodename = downcase($::facts['os']['distro']['codename'])
+      $_operatingsystem = downcase($facts['os']['name'])
+      $_oscodename = downcase($facts['os']['distro']['codename'])
 
       if ( $manage_repos ){
         apt::source { 'influxdb':
@@ -60,7 +60,7 @@ class puppet_metrics_dashboard::repos (
     }
 
     default: {
-      fail("${::osfamily} installation not supported")
+      fail("${facts['os']['family']} installation not supported")
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,14 @@
       "version_requirement": ">= 1.0.0 < 6.0.0"
     },
     {
+      "name": "puppetlabs-inifile",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">= 4.3.0 < 7.0.0"
+    },
+    {
       "name": "puppet-grafana",
       "version_requirement": ">= 3.0.0 < 6.0.0"
     }

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -27,7 +27,7 @@ describe 'puppet_metrics_dashboard::telegraf' do
   end
 
   it do
-    is_expected.to contain_file('/etc/telegraf/telegraf.conf').with(
+    is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf').with(
       ensure: 'file',
       owner: '0',
       group: '0',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,6 +27,7 @@ RSpec.configure do |c|
       end
 
       on host, puppet('module', 'install', 'puppet-grafana')
+      on host, puppet('module', 'install', 'puppetlabs-inifile')
       if fact('osfamily') == 'Debian'
         on host, puppet('module', 'install', 'puppetlabs-apt')
       end

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -1,25 +1,8 @@
-[global_tags]
-[agent]
-  interval = '10s'
-  round_interval = true
-  metric_batch_size = 1000
-  metric_buffer_limit = 10000
-  collection_jitter = '0s'
-  flush_interval = '10s'
-  flush_jitter = '0s'
-  precision = ''
-  debug = false
-  quiet = false
-  logfile = '/var/log/telegraf/telegraf.log'
-  hostname = ''
-  omit_hostname = false
-[[outputs.influxdb]]
-  urls = ['http://localhost:8086'] # required
-  database = 'telegraf' # required
-  retention_policy = ''
-  write_consistency = 'any'
-  timeout = '5s'
-
+<%- | Integer[1] $http_response_timeout,
+      Array[Hash] $puppetdb_metrics,
+      Array $master_list,
+      Array $puppetdb_list,
+| -%>
 [[inputs.httpjson]]
   name = 'puppet_stats'
   servers = [
@@ -47,6 +30,7 @@
   ]
   method = 'GET'
   insecure_skip_verify = true
+  response_timeout = '<%= $http_response_timeout %>s'
 
 <%# -%>
 <% unless $puppetdb_metrics.empty {-%>
@@ -64,6 +48,7 @@
   ]
   method = 'GET'
   insecure_skip_verify = true
+  response_timeout = '<%= $http_response_timeout %>s'
 
 <% } -%>
 <% } -%>


### PR DESCRIPTION
Parameters added:
- influxdb_urls
- telegraf_db_name
- telegraf_agent_interval
- http_response_timeout

Global telegraf settings are now managed via ini_setting resources.
Settings for this module are moved from telegraf.conf to
telegraf.d/puppet_metrics_dashboard.conf. These changes allow configs other
than the ones for this module to be set while still allowing this module
to udpate its config.

Update .fixtures and metadata (fixes #18)

Also removed top scope references and replaced legacy facts