### PR TITLE
Use a healthcheck as recommended by the puppet-grafana docs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,3 +16,4 @@ fixtures:
         repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
         ref: 1.0.2
     forge_modules:
+      healthcheck: "puppet/healthcheck"

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -184,6 +184,15 @@ The grafana port for the web interface. This should be a nonprivileged port (abo
 
 Default value: $puppet_metrics_dashboard::params::grafana_http_port
 
+##### `grafana_old_password`
+
+Data type: `String`
+
+The current password for the Grafana admin user. This is used when changing the password.
+Defaults to `'admin'`
+
+Default value: $puppet_metrics_dashboard::params::grafana_password
+
 ##### `grafana_password`
 
 Data type: `String`

--- a/manifests/grafana.pp
+++ b/manifests/grafana.pp
@@ -4,6 +4,9 @@
 # because it requires the InfluxDB service to be running before it can even
 # start doing its thing.
 #
+# Note: The curl command used to set the password during installation does not
+# validate the certificate of the Grafana server.
+#
 # @api private
 class puppet_metrics_dashboard::grafana {
   if $puppet_metrics_dashboard::use_dashboard_ssl {
@@ -35,6 +38,43 @@ class puppet_metrics_dashboard::grafana {
     manage_package_repo => false,
     version             => $puppet_metrics_dashboard::grafana_version,
     cfg                 => $grafana_cfg,
-    require             => Service[$puppet_metrics_dashboard::influx_db_service_name],
+    require             => Http_conn_validator['influxdb-conn-validator'],
+    notify              => Exec['update Grafana admin password'],
   }
+
+  $_uri = $puppet_metrics_dashboard::use_dashboard_ssl ? {
+    true    => 'https',
+    default => 'http',
+  }
+
+  http_conn_validator { 'grafana-conn-validator' :
+    host        => 'localhost',
+    port        => $puppet_metrics_dashboard::grafana_http_port,
+    use_ssl     => $puppet_metrics_dashboard::use_dashboard_ssl,
+    test_url    => '/public/img/grafana_icon.svg',
+    verify_peer => false,
+    try_sleep   => 10,
+    require     => Class['grafana'],
+  }
+
+  exec { 'update Grafana admin password':
+    path        => '/usr/bin',
+    command     => @("CHANGE_GRAFANA_PW"),
+      curl -k -X PUT -H "Content-Type: application/json" -d '{
+        "oldPassword": "${puppet_metrics_dashboard::grafana_old_password}",
+        "newPassword": "${puppet_metrics_dashboard::grafana_password}",
+        "confirmNew": "${puppet_metrics_dashboard::grafana_password}"
+      }' ${_uri}://admin:${puppet_metrics_dashboard::grafana_old_password}@localhost:${puppet_metrics_dashboard::grafana_http_port}/api/user/password
+      | CHANGE_GRAFANA_PW
+    cwd         => '/usr/share/grafana',
+    refreshonly => true,
+    require     => Http_conn_validator['grafana-conn-validator'],
+  }
+
+  Http_conn_validator <| title == 'grafana-conn-validator' |>
+  -> Grafana_datasource <| tag == 'puppet_metrics_dashboard' |>
+
+  Http_conn_validator <| title == 'grafana-conn-validator' |>
+  -> Grafana_dashboard <| tag == 'puppet_metrics_dashboard' |>
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,10 @@
 #   Valid values are Integers from `1024` to `65536`. Defaults to `3000`
 #   The grafana port for the web interface. This should be a nonprivileged port (above 1024).
 #
+# @param grafana_old_password
+#   The current password for the Grafana admin user. This is used when changing the password.
+#   Defaults to `'admin'`
+#
 # @param grafana_password
 #   The password for the Grafana admin user.
 #   Defaults to `'admin'`
@@ -174,6 +178,7 @@ class puppet_metrics_dashboard (
   String $grafana_version                 =  $puppet_metrics_dashboard::params::grafana_version,
   Integer $grafana_http_port              =  $puppet_metrics_dashboard::params::grafana_http_port,
   String $influx_db_password              =  $puppet_metrics_dashboard::params::influx_db_password,
+  String $grafana_old_password            =  $puppet_metrics_dashboard::params::grafana_password,
   String $grafana_password                =  $puppet_metrics_dashboard::params::grafana_password,
   Boolean $enable_kapacitor               =  $puppet_metrics_dashboard::params::enable_kapacitor,
   Boolean $enable_chronograf              =  $puppet_metrics_dashboard::params::enable_chronograf,
@@ -207,6 +212,7 @@ class puppet_metrics_dashboard (
   contain puppet_metrics_dashboard::grafana
   Class['puppet_metrics_dashboard::service']
   -> Class['puppet_metrics_dashboard::grafana']
+  -> Class['puppet_metrics_dashboard::post_start_configs']
 
   if $add_dashboard_examples {
     contain puppet_metrics_dashboard::dashboards
@@ -220,5 +226,10 @@ class puppet_metrics_dashboard (
 
   if $_enable_telegraf {
     contain puppet_metrics_dashboard::telegraf
+  }
+
+  if $_enable_telegraf and $manage_repos {
+    Class['puppet_metrics_dashboard::repos']
+    -> Class['puppet_metrics_dashboard::telegraf']
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class puppet_metrics_dashboard::params {
   $grafana_version         =  '5.1.4'
   $grafana_http_port       =  3000
   $influx_db_password      =  'puppet'
+  $grafana_old_password    =  'admin'
   $grafana_password        =  'admin'
   $consume_graphite        =  false
   # Influxdb TICK stack

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -9,9 +9,10 @@ class puppet_metrics_dashboard::repos {
       'RedHat': {
         yumrepo {'influxdb':
           ensure   => present,
+          descr    => 'InfluxDB Repository - RHEL $releasever',
+          baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
           enabled  => 1,
           gpgcheck => 1,
-          baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',
         }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,6 +10,16 @@ class puppet_metrics_dashboard::service {
     require => Package['influxdb'],
   }
 
+  http_conn_validator { 'influxdb-conn-validator' :
+    host        => 'localhost',
+    port        => 8086,
+    use_ssl     => false,
+    test_url    => '/ping?verbose=true',
+    verify_peer => false,
+    try_sleep   => 10,
+    require     => Service[$puppet_metrics_dashboard::influx_db_service_name],
+  }
+
   if $puppet_metrics_dashboard::enable_chronograf {
     service { 'chronograf':
       ensure  => running,

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
   "issues_url": "https://github.com/puppetlabs/puppet_metrics_dashboard/issues",
   "dependencies": [
     {
+      "name": "puppet-healthcheck",
+      "version_requirement": ">= 0.4.1 < 1.0.0"
+    },
+    {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 1.0.0 < 6.0.0"
     },

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -40,17 +40,16 @@ describe 'puppet_metrics_dashboard::grafana' do
             .with_manage_package_repo(false)
             .with_version('5.1.4')
             .with_cfg('server' => { 'http_port' => 3000 })
+            .with_require('Http_conn_validator[influxdb-conn-validator]')
+        end
 
-          case facts[:os]['family']
-          when 'Debian'
-            is_expected.to contain_class('grafana')
-              .with_require('Service[influxd]')
-          when 'RedHat'
-            is_expected.to contain_class('grafana')
-              .with_require('Service[influxdb]')
-          end
+        it 'should contain Http_conn_validator[grafana-conn-validator]' do
+          is_expected.to contain_http_conn_validator('grafana-conn-validator')
+            .with_test_url('/public/img/grafana_icon.svg')
         end
         # rubocop:enable RSpec/ExampleWording
+
+        it { is_expected.to contain_exec('update Grafana admin password') }
       end
 
       context 'with ssl enabled' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,6 +47,7 @@ describe 'puppet_metrics_dashboard' do
             .with_grafana_version('5.1.4')
             .with_grafana_http_port(3000)
             .with_influx_db_password('puppet')
+            .with_grafana_old_password('admin')
             .with_grafana_password('admin')
             .with_enable_kapacitor(false)
             .with_enable_chronograf(false)

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -24,12 +24,20 @@ describe 'puppet_metrics_dashboard::service' do
             is_expected.to contain_service('influxdb')
               .with_ensure('running')
               .with_enable(true)
+
+            is_expected.to contain_http_conn_validator('influxdb-conn-validator')
+              .with_test_url('/ping?verbose=true')
+              .with_require('Service[influxdb]')
           end
         when 'Debian'
           it do
             is_expected.to contain_service('influxd')
               .with_ensure('running')
               .with_enable(true)
+
+            is_expected.to contain_http_conn_validator('influxdb-conn-validator')
+              .with_test_url('/ping?verbose=true')
+              .with_require('Service[influxd]')
           end
         end
       end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,6 +27,7 @@ RSpec.configure do |c|
       end
 
       on host, puppet('module', 'install', 'puppet-grafana')
+      on host, puppet('module', 'install', 'puppet-healthcheck')
       on host, puppet('module', 'install', 'puppetlabs-inifile')
       if fact('osfamily') == 'Debian'
         on host, puppet('module', 'install', 'puppetlabs-apt')


### PR DESCRIPTION
This builds on #25. It implements some additional ordering of resources so that ones that require the API are not run before the API is up. 