### PR TITLE
(MODULES-8585) update grafana repos

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -17,12 +17,12 @@ class puppet_metrics_dashboard::repos {
 
         yumrepo { 'grafana-repo':
           ensure        => 'present',
-          baseurl       => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+          baseurl       => 'https://packages.grafana.com/oss/rpm',
           descr         => 'grafana-repository',
           enabled       => '1',
           repo_gpgcheck => '1',
           gpgcheck      => '1',
-          gpgkey        => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+          gpgkey        => 'https://packages.grafana.com/gpg.key',
           sslverify     => '1',
           sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
         }
@@ -43,12 +43,12 @@ class puppet_metrics_dashboard::repos {
         }
 
         apt::source { 'grafana':
-          location => 'https://packagecloud.io/grafana/stable/debian/',
-          release  => 'jessie',
+          location => 'https://packages.grafana.com/oss/deb',
+          release  => 'stable',
           repos    => 'main',
           key      =>  {
-            'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-            'source' => 'https://packagecloud.io/gpg.key',
+            'id'     => '4E40DDF6D76E284A4A6780E48C8C34C524098CB6',
+            'source' => 'https://packages.grafana.com/gpg.key',
           },
         }
       }

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -39,12 +39,12 @@ describe 'puppet_metrics_dashboard::repos' do
             is_expected.to contain_yumrepo('grafana-repo')
               .with(
                 'ensure' => 'present',
-                'baseurl' => 'https://packagecloud.io/grafana/stable/el/6/$basearch',
+                'baseurl' => 'https://packages.grafana.com/oss/rpm',
                 'descr' => 'grafana-repository',
                 'enabled' => '1',
                 'repo_gpgcheck' => '1',
                 'gpgcheck' => '1',
-                'gpgkey' => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
+                'gpgkey' => 'https://packages.grafana.com/gpg.key',
                 'sslverify' => '1',
                 'sslcacert' => '/etc/pki/tls/certs/ca-bundle.crt',
               )
@@ -62,8 +62,8 @@ describe 'puppet_metrics_dashboard::repos' do
           it 'should contain the yum repo for Grafana' do
             is_expected.to contain_apt__source('grafana')
               .with(
-                'location' => 'https://packagecloud.io/grafana/stable/debian/',
-                'release' => 'jessie',
+                'location' => 'https://packages.grafana.com/oss/deb',
+                'release' => 'stable',
                 'repos' => 'main',
               )
           end
@@ -80,8 +80,8 @@ describe 'puppet_metrics_dashboard::repos' do
           it 'should contain the yum repo for Grafana' do
             is_expected.to contain_apt__source('grafana')
               .with(
-                'location' => 'https://packagecloud.io/grafana/stable/debian/',
-                'release' => 'jessie',
+                'location' => 'https://packages.grafana.com/oss/deb',
+                'release' => 'stable',
                 'repos' => 'main',
               )
           end


### PR DESCRIPTION
Updates repo url and key, as per:

  https://grafana.com/blog/2019/01/05/moving-to-packages.grafana.com/
  https://github.com/voxpupuli/puppet-grafana/pull/150