### PR TITLE
add a metric for last successful file-sync commit

### DIFF
--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -18,6 +18,20 @@
   method = 'GET'
   insecure_skip_verify = true
 
+[[inputs.http]]
+  urls = [
+    <%# -%>
+    <% unless $master_list.empty {-%>
+    <% $master_list.each |$master| {-%>
+    "https://<%= $master %>:8140/status/v1/services/file-sync-client-service?level=debug",
+    <% } -%>
+    <% } -%>
+    <%# -%>
+  ]
+  insecure_skip_verify = true
+  data_format = "json"
+  json_string_fields = ["status_repos_puppet-code_latest_commit_date"]
+
 [[inputs.httpjson]]
   name = 'puppetdb_command_queue'
   servers = [


### PR DESCRIPTION
This commit will add a metric showing the last time code was successfully committed to any branch.  We can use this to identify issues where any of the masters aren't getting updated code.