### PR TITLE
Stop creating /run/grafana on CentOS 7

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,21 +4,6 @@
 #
 # @api private
 class puppet_metrics_dashboard::service {
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
-    file { '/usr/lib/tmpfiles.d/grafana.conf' :
-      ensure  => file,
-      content => 'd /var/run/grafana 0755 grafana grafana',
-      require => Package['grafana'],
-      before  => Service['grafana-server'],
-      notify  => Exec['Create Systemd Temp Files'],
-    }
-
-    exec { 'Create Systemd Temp Files':
-      command     => '/bin/systemd-tmpfiles --create',
-      refreshonly => true,
-    }
-  }
-
   service { $puppet_metrics_dashboard::influx_db_service_name:
     ensure  => running,
     enable  => true,

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -18,7 +18,6 @@ describe 'puppet_metrics_dashboard::service' do
           PRE_COND
         end
 
-        # rubocop:disable RSpec/RepeatedExample
         case facts[:os]['family']
         when 'RedHat'
           it do
@@ -27,16 +26,12 @@ describe 'puppet_metrics_dashboard::service' do
               .with_enable(true)
           end
         when 'Debian'
-          it { is_expected.not_to contain_file('/usr/lib/tmpfiles.d/grafana.conf') }
-          it { is_expected.not_to contain_exec('Create Systemd Temp Files') }
-
           it do
             is_expected.to contain_service('influxd')
               .with_ensure('running')
               .with_enable(true)
           end
         end
-        # rubocop:enable RSpec/RepeatedExample
       end
 
       context 'with alternate influx_db_service_name name' do

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -21,15 +21,6 @@ describe 'puppet_metrics_dashboard::service' do
         # rubocop:disable RSpec/RepeatedExample
         case facts[:os]['family']
         when 'RedHat'
-          case facts[:os]['release']['major']
-          when '7'
-            it { is_expected.to contain_file('/usr/lib/tmpfiles.d/grafana.conf').with_content('d /var/run/grafana 0755 grafana grafana') }
-            it { is_expected.to contain_exec('Create Systemd Temp Files').with_refreshonly(true) }
-          else
-            it { is_expected.not_to contain_file('/usr/lib/tmpfiles.d/grafana.conf') }
-            it { is_expected.not_to contain_exec('Create Systemd Temp Files') }
-          end
-
           it do
             is_expected.to contain_service('influxdb')
               .with_ensure('running')


### PR DESCRIPTION
This commit updates the service management logic for grafana to drop the
creation of the /run/grafana directory prior to starting the service on
CentOS 7. Grafana 4.5.0 and later manage this by setting the RuntimeDirectory
in the grafana-server.service unit file. However, CentOS 7 uses systemd v219
which will fail during startup if the directory specified by RuntimeDirectory
already exists. This failure causes the first catalog application that installs
and starts grafana-server to fail --- which is particularly problematic for
Bolt plans that only run once.