### PR TITLE
fix grafana version req.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The grafana module is at 6.0.0 now, so need to bump up the requirement in metadata