### PR TITLE
Allow port numbers of services to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ class { 'puppet_metrics_dashboard':
 class { 'puppet_metrics_dashboard':
   configure_telegraf  => true,
   enable_telegraf     => true,
-  master_list         => ['master1.com','master2.com'],
+  master_list         => ['master1.com',
+                          # Alternate ports may be configured using
+                          # a pair of: [hostname, port_number]
+                          ['master2.com', 9140]],
   puppetdb_list       => ['puppetdb1','puppetdb2'],
   postgres_host_list  => ['postgres01','postgres02'],
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,8 +76,14 @@
 #   Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
 #
 # @param master_list
-#   An array of Puppet Master servers to collect metrics from. Defaults to `[$trusted['certname']]`
-#   A list of Puppet master servers that will be configured for telegraf to query.
+#   A list of Puppet Master servers that Telegraf will be configured to
+#   collect metrics from. Entries in the list may be:
+#     - A single string that contains a hostname or IP address.
+#       The module will use a default port number of 8140.
+#     - A list of length two, where the first entry is a string that
+#       contains a hostname or IP address and the second entry is an
+#       integer that specifies the port number.
+#   Defaults to `[$trusted['certname']]`
 #
 # @param influxdb_urls
 #   The string for telegraf's config defining where influxdb is
@@ -98,11 +104,24 @@
 #   `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
 #
 # @param puppetdb_list
-#   An array of PuppetDB servers to collect metrics from. Defaults to `[$trusted['certname']]`
-#   A list of PuppetDB servers that will be configured for telegraf to query.
+#   A list of PuppetDB servers that Telegraf will be configured to
+#   collect metrics from. Entries in the list may be:
+#     - A single string that contains a hostname or IP address.
+#       The module will use a default port number of 8081.
+#     - A list of length two, where the first entry is a string that
+#       contains a hostname or IP address and the second entry is an
+#       integer that specifies the port number.
+#   Defaults to `[$trusted['certname']]`
 #
-# @param postgres_host_list
-#   An array of Postgres hosts to monitor.  Defaults to `[$trusted['certname']]`
+# @param puppetdb_list
+#   A list of PostgreSQL servers that Telegraf will be configured to
+#   collect metrics from. Entries in the list may be:
+#     - A single string that contains a hostname or IP address.
+#       The module will use a default port number of 5432.
+#     - A list of length two, where the first entry is a string that
+#       contains a hostname or IP address and the second entry is an
+#       integer that specifies the port number.
+#   Defaults to `[$trusted['certname']]`
 #
 # @param use_dashboard_ssl
 #   Whether to enable SSL on Grafana.
@@ -121,8 +140,12 @@
 #   class { 'puppet_metrics_dashboard':
 #     configure_telegraf  => true,
 #     enable_telegraf     => true,
-#     master_list         => ['master1.com','master2.com'],
-#     puppetdb_list       => ['puppetdb1','puppetdb2'],
+#     master_list         => ['master1.com',
+#                             # Alternate ports may be configured using
+#                             # a list of: `[hostname, port_number]`
+#                             ['master2.com', 9140]],
+#     puppetdb_list       => ['puppetdb1',
+#                             ['puppetdb2', 8100]],
 #   }
 #
 # @example Install example dashboards for all of the collection methods
@@ -180,9 +203,9 @@ class puppet_metrics_dashboard (
   Boolean $enable_telegraf                =  $puppet_metrics_dashboard::params::enable_telegraf,
   Boolean $configure_telegraf             =  $puppet_metrics_dashboard::params::configure_telegraf,
   Boolean $consume_graphite               =  $puppet_metrics_dashboard::params::consume_graphite,
-  Array[String] $master_list              =  $puppet_metrics_dashboard::params::master_list,
-  Array[String] $puppetdb_list            =  $puppet_metrics_dashboard::params::puppetdb_list,
-  Array[String] $postgres_host_list       =  $puppet_metrics_dashboard::params::postgres_host_list,
+  Puppet_metrics_dashboard::HostList $master_list        = $puppet_metrics_dashboard::params::master_list,
+  Puppet_metrics_dashboard::HostList $puppetdb_list      = $puppet_metrics_dashboard::params::puppetdb_list,
+  Puppet_metrics_dashboard::HostList $postgres_host_list = $puppet_metrics_dashboard::params::postgres_host_list,
   String $influxdb_urls                   =  $puppet_metrics_dashboard::params::influxdb_urls,
   String $telegraf_db_name                =  $puppet_metrics_dashboard::params::telegraf_db_name,
   Integer[1] $telegraf_agent_interval     =  $puppet_metrics_dashboard::params::telegraf_agent_interval,

--- a/spec/classes/telegraf/config_spec.rb
+++ b/spec/classes/telegraf/config_spec.rb
@@ -40,6 +40,67 @@ describe 'puppet_metrics_dashboard::telegraf::config' do
         it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_cert.pem') }
         it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_key.pem') }
       end
+
+      context 'when master_list includes entries with port numbers' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            class { 'puppet_metrics_dashboard':
+              master_list        => ['some-host.test',
+                                     ['some-other.host.test', 9140]],
+              puppetdb_list      => [],
+              postgres_host_list => [],
+            }
+          PRE_COND
+        end
+
+        it do
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-host\.test:8140})
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-other\.host\.test:9140})
+        end
+      end
+
+      context 'when puppetdb_list includes entries with port numbers' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            class { 'puppet_metrics_dashboard':
+              master_list        => [],
+              puppetdb_list      => ['some-host.test',
+                                     ['some-other.host.test', 8100]],
+              postgres_host_list => [],
+            }
+          PRE_COND
+        end
+
+        it do
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-host\.test:8081})
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-other\.host\.test:8100})
+        end
+      end
+
+      context 'when postgres_host_list includes entries with port numbers' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            class { 'puppet_metrics_dashboard':
+              master_list        => [],
+              puppetdb_list      => [],
+              postgres_host_list => ['some-host.test',
+                                     ['some-other.host.test', 9000]],
+
+            }
+          PRE_COND
+        end
+
+        it do
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-host\.test:5432})
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{some-other\.host\.test:9000})
+        end
+      end
     end
   end
 end

--- a/spec/type_aliases/puppet_metrics_dashboard_host_list_spec.rb
+++ b/spec/type_aliases/puppet_metrics_dashboard_host_list_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'Puppet_metrics_dashboard::HostList' do
+  it do
+    is_expected.to allow_value(['some-host.test',
+                                'some-other.host.test'])
+  end
+  it do
+    is_expected.to allow_value(['some-host.test',
+                                ['some-other.host.test', 9140]])
+  end
+
+  it do
+    is_expected.not_to allow_value([['some-host.test', '9140']])
+  end
+end

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -1,8 +1,8 @@
 <%- | Integer[1] $http_response_timeout,
       Array[Hash] $puppetdb_metrics,
-      Array $master_list,
-      Array $puppetdb_list,
-      Array $postgres_host_list,
+      Array[String] $master_list,
+      Array[String] $puppetdb_list,
+      Array[String] $postgres_host_list,
 | -%>
 [[inputs.httpjson]]
   name = 'puppet_stats'
@@ -10,7 +10,7 @@
     <%# -%>
     <% unless $master_list.empty {-%>
     <% $master_list.each |$master| {-%>
-    "https://<%= $master %>:8140/status/v1/services?level=debug",
+    "https://<%= $master %>/status/v1/services?level=debug",
     <% } -%>
     <% } -%>
     <%# -%>
@@ -23,7 +23,7 @@
     <%# -%>
     <% unless $master_list.empty {-%>
     <% $master_list.each |$master| {-%>
-    "https://<%= $master %>:8140/status/v1/services/file-sync-client-service?level=debug",
+    "https://<%= $master %>/status/v1/services/file-sync-client-service?level=debug",
     <% } -%>
     <% } -%>
     <%# -%>
@@ -38,7 +38,7 @@
     <%# -%>
     <% unless $puppetdb_list.empty {-%>
     <% $puppetdb_list.each |$puppetdb| {-%>
-    "https://<%= $puppetdb %>:8081/status/v1/services?level=debug",
+    "https://<%= $puppetdb %>/status/v1/services?level=debug",
     <% } -%>
     <% } -%>
     <%# -%>
@@ -56,7 +56,7 @@
     <%# -%>
     <% unless $puppetdb_list.empty {-%>
     <% $puppetdb_list.each |$puppetdb| {-%>
-    "https://<%= $puppetdb %>:8081/metrics/v1/mbeans/<%= $metric['url'] %>",
+    "https://<%= $puppetdb %>/metrics/v1/mbeans/<%= $metric['url'] %>",
     <% } -%>
     <% } -%>
     <%# -%>

--- a/types/hostlist.pp
+++ b/types/hostlist.pp
@@ -1,0 +1,7 @@
+# A list of hostnames, or pairs of hostname and port.
+type Puppet_metrics_dashboard::HostList = Array[
+  Variant[
+    String,
+    Tuple[String, Integer]
+  ]
+]


### PR DESCRIPTION
This commit updates the master_list, puppetdb_list, and postgres_host_list
parameters to allow pairs of `[hostname, port_number]` in addition to just
a hostname. If the port number is specified, then Telegraf will be configured
to use that port when requesting metrics from the host. If no port number is
specified, then Telegraf will be configured to use the default prts of
8140 for Puppet Server, 8081 for PuppetDB, and 5432 for Postgres.

Closes puppetlabs/puppet_metrics_dashboard#48