### PR TITLE
Update dashboard templates

### DIFF
--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 9,
   "links": [

--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -29,7 +29,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -330,7 +330,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -610,7 +610,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -890,6 +890,21 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "influxdb_puppet_metrics",
+          "value": "influxdb_puppet_metrics"
+        },
+        "hide": 0,
+        "label": "datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
@@ -897,7 +912,7 @@
             "$__all"
           ]
         },
-        "datasource": "influxdb_telegraf",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "server",

--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 9,
+  "id": null,
   "links": [
     {
       "icon": "external link",

--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -13,7 +13,7 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "telegraf"
+        "archive"
       ],
       "type": "dashboards"
     }
@@ -885,8 +885,7 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "telegraf",
-    "puppetserver"
+    "archive"
   ],
   "templating": {
     "list": [

--- a/files/Graphite_Puppetserver_Performance.json
+++ b/files/Graphite_Puppetserver_Performance.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 4,
+  "id": null,
   "links": [
     {
       "icon": "external link",

--- a/files/Graphite_Puppetserver_Performance.json
+++ b/files/Graphite_Puppetserver_Performance.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 4,
   "links": [

--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -1,39 +1,8 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB_PE_METRICS",
-      "label": "influxdb_puppet_metrics",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.5.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
   "id": null,

--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -59,7 +59,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -177,7 +177,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -307,7 +307,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -437,7 +437,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -555,7 +555,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -673,7 +673,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -803,9 +803,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "influxdb_puppet_metrics",
+          "value": "influxdb_puppet_metrics"
+        },
+        "hide": 0,
+        "label": "datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "influxdb_puppet_metrics",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "server",

--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -34,7 +34,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": null,
   "links": [

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -1,39 +1,8 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB_PE_METRICS",
-      "label": "influxdb_puppet_metrics",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.5.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
   "id": null,

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -60,7 +60,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -190,7 +190,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -308,7 +308,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -426,7 +426,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -556,7 +556,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -674,7 +674,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -792,7 +792,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 7,
           "legend": {
@@ -922,7 +922,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 8,
           "legend": {
@@ -1040,7 +1040,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 9,
           "legend": {
@@ -1170,9 +1170,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "influxdb_puppet_metrics",
+          "value": "influxdb_puppet_metrics"
+        },
+        "hide": 0,
+        "label": "datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "influxdb_puppet_metrics",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "server",

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -34,7 +34,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": null,
   "links": [

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -1,39 +1,8 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB_PE_METRICS",
-      "label": "influxdb_puppet_metrics",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.5.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
   "id": null,

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -59,7 +59,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -356,7 +356,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -599,7 +599,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -717,7 +717,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 4,
           "legend": {
@@ -897,7 +897,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -1015,7 +1015,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "influxdb_puppet_metrics",
+          "datasource": "$datasource",
           "fill": 1,
           "id": 6,
           "legend": {
@@ -1145,9 +1145,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "influxdb_puppet_metrics",
+          "value": "influxdb_puppet_metrics"
+        },
+        "hide": 0,
+        "label": "datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "influxdb_puppet_metrics",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "server",

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -34,7 +34,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": null,
   "links": [

--- a/files/Telegraf_FOSS_Puppetserver_Performance.json
+++ b/files/Telegraf_FOSS_Puppetserver_Performance.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 6,
   "links": [

--- a/files/Telegraf_FOSS_Puppetserver_Performance.json
+++ b/files/Telegraf_FOSS_Puppetserver_Performance.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 6,
+  "id": null,
   "links": [
     {
       "icon": "external link",

--- a/files/Telegraf_File_Sync.json
+++ b/files/Telegraf_File_Sync.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 65,
   "links": [

--- a/files/Telegraf_File_Sync.json
+++ b/files/Telegraf_File_Sync.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 65,
+  "id": null,
   "links": [
     {
       "icon": "external link",

--- a/files/Telegraf_Postgres.json
+++ b/files/Telegraf_Postgres.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "links": [
     {

--- a/files/Telegraf_Postgres.json
+++ b/files/Telegraf_Postgres.json
@@ -3,7 +3,6 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "id": null,
   "links": [

--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -1,34 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_INFLUXDB_TELEGRAF",
-      "label": "influxdb_telegraf",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.1.4"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -43,7 +13,6 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "id": null,
   "iteration": 1553288260160,

--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -44,7 +44,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "iteration": 1553288260160,
   "links": [

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 5,
   "links": [

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 5,
+  "id": null,
   "links": [
     {
       "icon": "external link",

--- a/files/Telegraf_Puppetserver_Performance.json
+++ b/files/Telegraf_Puppetserver_Performance.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": false,
   "id": 6,
   "links": [

--- a/files/Telegraf_Puppetserver_Performance.json
+++ b/files/Telegraf_Puppetserver_Performance.json
@@ -3,10 +3,9 @@
     "list": []
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 6,
+  "id": null,
   "links": [
     {
       "icon": "external link",


### PR DESCRIPTION
This PR improves the dashboard templates in two ways:

  - All dashboards now use a shared crosshair. This allows values to be easily compared at the same moment in time between graphs that are not vertically stacked.

  - The Archive dashboards now have a `$datasource` variable that can be used to flip between different datasources. This is allows metrics from separate PE installations to be loaded into separate InfluxDB databases without requiring dashboards to be copied for each.

Unused entries in the JSON are also cleaned up.