### PR TITLE
Ensure http timeout is set in all inputs.http* for telegraf

### DIFF
--- a/spec/classes/telegraf/config_spec.rb
+++ b/spec/classes/telegraf/config_spec.rb
@@ -101,6 +101,22 @@ describe 'puppet_metrics_dashboard::telegraf::config' do
             .with_content(%r{some-other\.host\.test:9000})
         end
       end
+      context 'when http_response_timeout is set' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            class { 'puppet_metrics_dashboard':
+              http_response_timeout => 123,
+            }
+          PRE_COND
+        end
+
+        it do
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{\s*timeout\s*=\s*\'123s\'})
+          is_expected.to contain_file('/etc/telegraf/telegraf.d/puppet_metrics_dashboard.conf')\
+            .with_content(%r{\s*response_timeout\s*=\s*\'123s\'})
+        end
+      end
     end
   end
 end

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -17,6 +17,7 @@
   ]
   method = 'GET'
   insecure_skip_verify = true
+  response_timeout = '<%= $http_response_timeout %>s'
 
 [[inputs.http]]
   urls = [
@@ -31,6 +32,7 @@
   insecure_skip_verify = true
   data_format = "json"
   json_string_fields = ["status_repos_puppet-code_latest_commit_date"]
+  timeout = '<%= $http_response_timeout %>s'
 
 [[inputs.httpjson]]
   name = 'puppetdb_command_queue'


### PR DESCRIPTION
Prior to this commit, the http_response_timeout did not apply to the
puppetserver status API call in telegraf, so setting it had no effect on
the timeout. This commit adds the timeout to all `inputs.http` and
`inputs.httpjson` items in the `telegraf.conf.epp`.

Prior to this PR, we were seeing timeouts on the puppetserver status endpoint and there was no way to set it in the configuration file.