### PR TITLE
Use certname consistently for key files

### DIFF
--- a/manifests/certs.pp
+++ b/manifests/certs.pp
@@ -4,8 +4,8 @@ define puppet_metrics_dashboard::certs(
 
   $ssl_dir        = $settings::ssldir
   $cert_dir       = "/etc/${service}"
-  $client_pem_key = "${ssl_dir}/private_keys/${facts['networking']['fqdn']}.pem"
-  $client_cert    = "${ssl_dir}/certs/${facts['networking']['fqdn']}.pem"
+  $client_pem_key = "${ssl_dir}/private_keys/${trusted['certname']}.pem"
+  $client_cert    = "${ssl_dir}/certs/${trusted['certname']}.pem"
 
   File {
     owner   => $service,

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -72,7 +72,7 @@
 <% unless $postgres_host_list.empty {-%>
 <% $postgres_host_list.each | $pg_host| {-%>
 [[inputs.postgresql_extensible]]
-  address = "postgres://telegraf@<%= $pg_host %>/pe-puppetdb?sslmode=require&sslkey=/etc/telegraf/<%= $facts['networking']['fqdn'] %>_key.pem&sslcert=/etc/telegraf/<%= $facts['networking']['fqdn'] %>_cert.pem&sslrootcert=/etc/telegraf/ca.pem"
+  address = "postgres://telegraf@<%= $pg_host %>/pe-puppetdb?sslmode=require&sslkey=/etc/telegraf/<%= $trusted['certname'] %>_key.pem&sslcert=/etc/telegraf/<%= $trusted['certname'] %>_cert.pem&sslrootcert=/etc/telegraf/ca.pem"
   outputaddress = "<%= $pg_host %>"
   databases = ["pe-puppetdb","pe-rbac","pe-activity","pe-classifier"]
   [[inputs.postgresql_extensible.query]]


### PR DESCRIPTION
Previously, this module did not work for environments where certname != FQDN. With this change, certname is consistently used instead of FQDN when naming certificate/key files.