### PR TITLE
Improve PuppetDB metric dashboards

### DIFF
--- a/files/PuppetDB_Performance.json
+++ b/files/PuppetDB_Performance.json
@@ -124,7 +124,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "wps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -243,7 +243,7 @@
           "yaxes": [
             {
               "format": "ms",
-              "label": null,
+              "label": "95th Percentile",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -503,7 +503,7 @@
           "yaxes": [
             {
               "format": "ms",
-              "label": null,
+              "label": "95th Percentile",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -621,7 +621,7 @@
           "yaxes": [
             {
               "format": "ms",
-              "label": null,
+              "label": "95th Percentile",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -739,7 +739,7 @@
           "yaxes": [
             {
               "format": "ms",
-              "label": null,
+              "label": "95th Percentile",
               "logBase": 1,
               "max": null,
               "min": null,

--- a/files/PuppetDB_Workload.json
+++ b/files/PuppetDB_Workload.json
@@ -78,7 +78,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "global_message-persistence-time.FiveMinuteRate",
+              "measurement": "global_message-persistence-time.Mean",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -87,7 +87,7 @@
                 [
                   {
                     "params": [
-                      "FiveMinuteRate"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -109,7 +109,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Command Persistance Time",
+          "title": "Average Command Persistance Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -125,7 +125,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -208,7 +208,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "PDBReadPool_pool_Usage.50thPercentile",
+              "measurement": "PDBReadPool_pool_Usage.Mean",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -217,7 +217,7 @@
                 [
                   {
                     "params": [
-                      "50thPercentile"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -239,7 +239,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Read Pool Usage",
+          "title": "Average Read Duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -255,7 +255,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -326,7 +326,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "PDBReadPool_pool_Wait.FifteenMinuteRate",
+              "measurement": "PDBReadPool_pool_Wait.999thPercentile",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -335,7 +335,7 @@
                 [
                   {
                     "params": [
-                      "FifteenMinuteRate"
+                      "999thPercentile"
                     ],
                     "type": "field"
                   },
@@ -357,7 +357,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Read Pool Wait",
+          "title": "Peak Read Pool Wait",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -373,7 +373,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -574,7 +574,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "PDBWritePool_pool_Usage.50thPercentile",
+              "measurement": "PDBWritePool_pool_Usage.Mean",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -583,7 +583,7 @@
                 [
                   {
                     "params": [
-                      "50thPercentile"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -605,7 +605,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Write Pool Usage",
+          "title": "Average Write Duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -621,7 +621,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -692,7 +692,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "PDBWritePool_pool_Wait.FifteenMinuteRate",
+              "measurement": "PDBWritePool_pool_Wait.999thPercentile",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -701,7 +701,7 @@
                 [
                   {
                     "params": [
-                      "FifteenMinuteRate"
+                      "999thPercentile"
                     ],
                     "type": "field"
                   },
@@ -723,7 +723,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Write Pool Wait",
+          "title": "Peak Write Pool Wait",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -739,7 +739,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -988,7 +988,7 @@
           "yaxes": [
             {
               "format": "short",
-              "label": null,
+              "label": "Discards per Second",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -1106,7 +1106,7 @@
           "yaxes": [
             {
               "format": "short",
-              "label": null,
+              "label": "Fatalities per Second",
               "logBase": 1,
               "max": null,
               "min": null,

--- a/files/Telegraf_PuppetDB_Performance.json
+++ b/files/Telegraf_PuppetDB_Performance.json
@@ -135,7 +135,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "wps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -223,7 +223,7 @@
             [
               {
                 "params": [
-                  "FiveMinuteRate"
+                  "95thPercentile"
                 ],
                 "type": "field"
               },
@@ -262,7 +262,7 @@
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
+          "label": "95th Percentile",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -725,7 +725,7 @@
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
+          "label": "95th Percentile",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -851,7 +851,7 @@
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
+          "label": "95th Percentile",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -977,7 +977,7 @@
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
+          "label": "95th Percentile",
           "logBase": 1,
           "max": null,
           "min": null,

--- a/files/Telegraf_PuppetDB_Workload.json
+++ b/files/Telegraf_PuppetDB_Workload.json
@@ -84,7 +84,7 @@
                 [
                   {
                     "params": [
-                      "FiveMinuteRate"
+                      "Mean"
                     ],
                     "type": "field"
                   },
@@ -106,7 +106,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Command Persistence Time",
+          "title": "Average Command Persistence Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -122,7 +122,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -238,7 +238,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Read Pool Usage",
+          "title": "Average Read Duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -254,7 +254,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -333,7 +333,7 @@
                 [
                   {
                     "params": [
-                      "Mean"
+                      "999thPercentile"
                     ],
                     "type": "field"
                   },
@@ -355,7 +355,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Read Pool Wait",
+          "title": "Peak Read Pool Wait",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -371,7 +371,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -601,7 +601,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Write Pool Usage",
+          "title": "Average Write Duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -617,7 +617,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -696,7 +696,7 @@
                 [
                   {
                     "params": [
-                      "Mean"
+                      "999thPercentile"
                     ],
                     "type": "field"
                   },
@@ -718,7 +718,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Write Pool Wait",
+          "title": "Peak Write Pool Wait",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -734,7 +734,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
This commit updates the archive and telegraf dashboards for PuppetDB:

  - Several instances of rate metrics being presented as durations have
    been fixed. If 8 command processing threads concurrently finish jobs
    that each took 5 minutes, then the rate at that moment is 0.02 per second,
    but the duration was 5 minutes.

  - Graph titles and axis labels have been improved.

  - Y-Axis have been changed from "short" to appropriate measurements
    like "milliseconds" or "writes per second".