### PR TITLE
Fix archive dashboard query for compile time

### DIFF
--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -800,7 +800,7 @@
                   },
                   {
                     "params": [],
-                    "type": "mean"
+                    "type": "distinct"
                   }
                 ]
               ],
@@ -809,6 +809,12 @@
                   "key": "server",
                   "operator": "=~",
                   "value": "/^$server$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "name",
+                  "operator": "=~",
+                  "value": "/^compile$|^static_compile$/"
                 }
               ]
             }


### PR DESCRIPTION
This commit updates the "Archive Puppetserver Performance" dashboard
template with two fixes for the catalog compile time metric:

  - The `mean()` function is replaced with `distinct()` so that null
    values are properly handled.

  - The `catalog-metrics` measurement is an array of different
    timings of operations that make up compilation. The query
    is updated to select only `compile` and `static_compile`
    operations.