### PR TITLE
Switching to in module hiera data & updating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,44 @@
 # puppet_metrics_dashboard
 
-## Table of Contents
-
-1. [Description](#description)
-2. [Setup - The basics of getting started with puppet_metrics_dashboard](#setup)
-  * [Upgrade note](#upgrade-note)
-  * [Beginning with puppet_metrics_dashboard](#beginning-with-puppet_metrics_dashboard)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+- [Description](#Description)
+- [Setup](#Setup)
+  - [Upgrade notes, breaking changes in v2](#Upgrade-notes-breaking-changes-in-v2)
+  - [Determining where Telegraf runs](#Determining-where-Telegraf-runs)
+  - [Beginning with puppet_metrics_dashboard](#Beginning-with-puppetmetricsdashboard)
+    - [Minimal configuration](#Minimal-configuration)
+- [Usage](#Usage)
+  - [To install example dashboards and use the Telegraf collection method (default)](#To-install-example-dashboards-and-use-the-Telegraf-collection-method-default)
+  - [Configure Telegraf for one or more masters / PuppetDB nodes / Postgres nodes](#Configure-Telegraf-for-one-or-more-masters--PuppetDB-nodes--Postgres-nodes)
+  - [Enable Graphite support](#Enable-Graphite-support)
+  - [Enable Telegraf, Graphite, and Archive (puppet_metrics)](#Enable-Telegraf-Graphite-and-Archive-puppetmetrics)
+  - [Enable SSL](#Enable-SSL)
+  - [Allow access to PE-managed Postgres nodes with the following class](#Allow-access-to-PE-managed-Postgres-nodes-with-the-following-class)
+  - [Profile defined types](#Profile-defined-types)
+    - [Note on using the defined types](#Note-on-using-the-defined-types)
+  - [Other possibilities](#Other-possibilities)
+- [Reference](#Reference)
+- [Limitations](#Limitations)
+  - [Repo failure for InfluxDB packages](#Repo-failure-for-InfluxDB-packages)
+  - [Postgres metrics collection requires Telegraf version 1.9.1 or later](#Postgres-metrics-collection-requires-Telegraf-version-191-or-later)
+- [Development](#Development)
 
 ## Description
 
-This module is used to configure grafana and influxdb to consume metrics from Puppet services.
-By default the metrics collection is done by another service called telegraf.
+This module is used to configure Grafana and InfluxDB to consume metrics from Puppet services.
+By default the metrics collection is done by [Telegraf](https://github.com/influxdata/telegraf).
 
 These services can all run on a single server by applying the base class.  You also have the option
-to use the [included defined types](#profile-defined-types) to configure telegraf on each of your Puppet infrastructure components
-(master,compilers, puppetdb, postgres server) and the metrics will be stored on another server
-running grafana and influxdb.  In environments where there is an existing grafana / influxdb
-instance, the later option is recommended. See [Determining where telegraf runs](#determining-where-telegraf-runs) for further
+to use the [included defined types](#profile-defined-types) to configure Telegraf on each of your Puppet infrastructure components
+(master, compilers, PuppetDB, Postgres server) and the metrics will be stored on another server
+running Grafana and InfluxDB.  In environments where there is an existing Grafana / InfluxDB
+instance, the later option is recommended. See [Determining where Telegraf runs](#determining-where-telegraf-runs) for further
 details.
 
 You have the option of collecting metrics using any or all of these methods:
 
-* Through telegraf, which polls several of Puppet's metrics endpoints (recommended)
-* Through Archive files from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
-* Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2019.0/getting_started_with_graphite.html#task-7933)
+- Through Telegraf, which polls several of Puppet's metrics endpoints (recommended)
+- Through Archive files from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
+- Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2019.0/getting_started_with_graphite.html#task-7933)
 
 ## Setup
 
@@ -45,45 +56,45 @@ module-specific settings now reside in individual files within
 `/etc/telegraf/telegraf.d/`. Telegraf will continue to work if you do not remove them, however, the old
 `[[inputs.httpjson]]` will not be updated going forward.
 
-### Determining where telegraf runs
+### Determining where Telegraf runs
 
-Telegraf can run on the grafana server or on each Puppet infrastructure node.  To configure telegraf to run on the same host that
-grafana runs on, use the `puppet_metrics_dashboard` class and the parameters: `master_list`, `puppetdb_list` and `postgres_host_list`.  These parameters determine which hosts that telegraf polls.
+Telegraf can run on the Grafana server or on each Puppet infrastructure node.  To configure Telegraf to run on the same host that
+Grafana runs on, use the `puppet_metrics_dashboard` class and the parameters: `master_list`, `puppetdb_list` and `postgres_host_list`.  These parameters determine which hosts that Telegraf polls.
 
-To configure telegraf to run on each Puppet infrastructure node, use the corresponding profiles for those hosts.  See [Profile defined types](#profile-defined-types).  The `puppet_metrics_dashboard` class is still applied to a separate host to setup grafana and influxdb and the profile classes configure telegraf when applied to your Puppet infrastructure hosts.
+To configure Telegraf to run on each Puppet infrastructure node, use the corresponding profiles for those hosts.  See [Profile defined types](#profile-defined-types).  The `puppet_metrics_dashboard` class is still applied to a separate host to setup Grafana and InfluxDB and the profile classes configure Telegraf when applied to your Puppet infrastructure hosts.
 
 ### Beginning with puppet_metrics_dashboard
 
 #### Minimal configuration
 
-Configures grafana-server, influxdb, and telegraf, with an influxdb datasource and a database called "puppet_metrics"
+Configures Grafana, InfluxDB, and Telegraf, with an InfluxDB datasource and a database called "puppet_metrics"
 
-```
+```puppet
 include puppet_metrics_dashboard
 ```
 
 ## Usage
 
-### To install example dashboards and use the telegraf collection method (default):
+### To install example dashboards and use the Telegraf collection method (default)
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
 }
 ```
 
-* `add_dashboard_examples` enforces state on the dashboards. Remove this later if you want to make edits to the examples or add the `overwrite_dashboards` parameter to disable overwriting the dashboards after the first run.
+> `add_dashboard_examples` enforces state on the dashboards. Remove this later if you want to make edits to the examples or add the `overwrite_dashboards` parameter to disable overwriting the dashboards after the first run.
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
   overwrite_dashboards   => false,
 }
 ```
 
-### Configure telegraf for one or more masters / puppetdb nodes / postgres nodes:
+### Configure Telegraf for one or more masters / PuppetDB nodes / Postgres nodes
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   master_list         => ['master1.com',
                           # Alternate ports may be configured using
@@ -96,7 +107,7 @@ class { 'puppet_metrics_dashboard':
 
 ### Enable Graphite support
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
   consume_graphite       => true,
@@ -109,7 +120,7 @@ class { 'puppet_metrics_dashboard':
 
 ### Enable Telegraf, Graphite, and Archive (puppet_metrics)
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
   influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
@@ -119,7 +130,7 @@ class { 'puppet_metrics_dashboard':
 
 ### Enable SSL
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   use_dashboard_ssl => true,
 }
@@ -131,11 +142,11 @@ By default, this will create a set of certificates in `/etc/grafana` that are ba
 
 _Note:_ Enabling SSL on Grafana will not allow for running on privileged ports such as `443`. To enable this capability you can use the suggestions documented in [this Grafana documentation](http://docs.grafana.org/installation/configuration/#http-port)
 
-### Allow access to PE-managed postgres nodes with the following class:
+### Allow access to PE-managed Postgres nodes with the following class
 
-This is required for collection of postgres metrics.  The class should be applied to the master (or postgres server if using external postgres).
+This is required for collection of Postgres metrics.  The class should be applied to the master (or Postgres server if using external Postgres).
 
-```
+```puppet
 class { 'puppet_metrics_dashboard::profile::master::postgres_access':
   telegraf_host => 'grafana-server.example.com',
 }
@@ -145,47 +156,17 @@ class { 'puppet_metrics_dashboard::profile::master::postgres_access':
 
 ### Profile defined types
 
-The module includes defined types that you can use with an existing grafana implementation.  For example:
-
-#### Add telegraf to a master / compiler
-
-```
-puppet_metrics_dashboard::profile::compiler{ $facts['networking']['fqdn']:
-  timeout => '5s',
-}
-```
-
-#### Add telegraf to a puppetdb node (see params.pp for `puppetdb_metrics` examples)
-
-```
-puppet_metrics_dashboard::profile::puppetdb{ $facts['networking']['fqdn']:
-  timeout => '5s',
-  puppetdb_metrics => [
-  { 'name' => 'global_command-parse-time',
-    'url'  => 'puppetlabs.puppetdb.mq:name=global.command-parse-time' },
-  { 'name' => 'global_discarded',
-    'url'  => 'puppetlabs.puppetdb.mq:name=global.discarded' },
-  ]
-}
-```
-
-#### Add telegraf to a postgres server
-
-```
-puppet_metrics_dashboard::profile::master::postgres{ $facts['networking']['fqdn']:
-  query_interval => '10m',
-}
-```
+The module includes defined types that you can use with an existing Grafana implementation. See [REFERENCE.md](REFERENCE.md) for example usage.
 
 #### Note on using the defined types
 
-Because of the way that the telegraf module works, these examples will overwrite any configuration in telegraf.config if it is *not* already puppet-managed.  See the [puppet-telegraf documentation](https://forge.puppet.com/puppet/telegraf#usage) on how to manage this file and add important settings.
+Because of the way that the Telegraf module works, these examples will overwrite any configuration in `telegraf.conf` if it is *not* already puppet-managed.  See the [puppet-telegraf documentation](https://forge.puppet.com/puppet/telegraf#usage) on how to manage this file and add important settings.
 
 ### Other possibilities
 
 Configure the passwords for the InfluxDB and enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components.
 
-```
+```puppet
 class { 'puppet_metrics_dashboard':
   influx_db_password  => 'secret',
   grafana_http_port   => 8080,
@@ -197,25 +178,28 @@ class { 'puppet_metrics_dashboard':
 
 ## Reference
 
-**Note** This section is no longer maintained. Please see the REFERENCE.MD file for current listings.
+This module is documented via
+`pdk bundle exec puppet strings generate --format markdown`.
+Please see [REFERENCE.md](REFERENCE.md) for more info.
 
 ## Limitations
 
 ### Repo failure for InfluxDB packages
-When installing InfluxDB on Centos/RedHat 6 or 7 you may encounter the following error message. This is due to a mismatch in the ciphers available on the local OS and on the InfluxDB repo.
 
-```
+When installing InfluxDB on CentOS/RedHat 6 or 7 you may encounter the following error message. This is due to a mismatch in the ciphers available on the local OS and on the InfluxDB repo.
+
+```puppet
 Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
 Error: /Stage[main]/Pe_metrics_dashboard::Telegraf/Package[telegraf]/ensure: change from purged to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
 ```
 
 To rectify the issue, please update `nss` and `curl` on the affected system.
 
-```
+```bash
 yum install curl nss --disablerepo influxdb
 ```
 
-### Postgres metrics collection requires telegraf version 1.9.1 or later
+### Postgres metrics collection requires Telegraf version 1.9.1 or later
 
 ## Development
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,36 @@
+---
+# Default Installation parameters
+puppet_metrics_dashboard::add_dashboard_examples     : false
+puppet_metrics_dashboard::manage_repos               : true
+puppet_metrics_dashboard::overwrite_dashboards       : true
+puppet_metrics_dashboard::use_dashboard_ssl          : false
+puppet_metrics_dashboard::dashboard_cert_file        : "/etc/grafana/%{clientcert}_cert.pem"
+puppet_metrics_dashboard::dashboard_cert_key         : "/etc/grafana/%{clientcert}_key.pem"
+puppet_metrics_dashboard::influxdb_database_name     :
+  - 'telegraf'
+puppet_metrics_dashboard::grafana_version            : '5.1.4'
+puppet_metrics_dashboard::grafana_http_port          : 3000
+puppet_metrics_dashboard::influx_db_password         : 'puppet'
+puppet_metrics_dashboard::grafana_password           : 'admin'
+puppet_metrics_dashboard::consume_graphite           : false
+# Influxdb TICK stack
+puppet_metrics_dashboard::enable_telegraf            : true
+puppet_metrics_dashboard::enable_kapacitor           : false
+puppet_metrics_dashboard::enable_chronograf          : false
+# telegraf config
+puppet_metrics_dashboard::configure_telegraf         : true
+puppet_metrics_dashboard::master_list                :
+  - "%{trusted.certname}"
+puppet_metrics_dashboard::puppetdb_list              :
+  - "%{trusted.certname}"
+puppet_metrics_dashboard::postgres_host_list         :
+  - "%{trusted.certname}"
+puppet_metrics_dashboard::influxdb_urls              :
+  - 'http://localhost:8086'
+puppet_metrics_dashboard::telegraf_db_name           : 'telegraf'
+puppet_metrics_dashboard::telegraf_agent_interval    : '5s'
+puppet_metrics_dashboard::http_response_timeout      : '5s' # this is the default value for the HTTP JSON Input
+puppet_metrics_dashboard::pg_query_interval          : '10m'
+
+puppet_metrics_dashboard::overwrite_dashboards_file  : '/opt/puppetlabs/puppet/cache/state/overwrite_dashboards_disabled'
+

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+---
+puppet_metrics_dashboard::influx_db_service_name: 'influxd'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+puppet_metrics_dashboard::influx_db_service_name: 'influxdb'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,12 @@
+---
+version: 5
+hierarchy:
+  - name: 'OS family'
+    data_hash: yaml_data
+    datadir: data
+    path: "os/%{facts.os.family}.yaml"
+  - name: 'Common'
+    data_hash: yaml_data
+    datadir: data
+    path: 'common.yaml'
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,10 @@
 #       integer that specifies the port number.
 #   Defaults to `[$trusted['certname']]`
 #
+# @param puppetdb_metrics
+#   An array of hashes containing name / url pairs for each puppetdb metric.
+#   See functions/puppetdb_metrics.pp for defaults.
+#
 # @param influxdb_urls
 #   An array for telegraf's config defining where influxdb instances are
 #
@@ -188,34 +192,38 @@
 #   }
 #
 class puppet_metrics_dashboard (
-  Boolean $add_dashboard_examples         =  $puppet_metrics_dashboard::params::add_dashboard_examples,
-  Boolean $manage_repos                   =  $puppet_metrics_dashboard::params::manage_repos,
-  Boolean $use_dashboard_ssl              =  $puppet_metrics_dashboard::params::use_dashboard_ssl,
-  String $dashboard_cert_file             =  $puppet_metrics_dashboard::params::dashboard_cert_file,
-  String $dashboard_cert_key              =  $puppet_metrics_dashboard::params::dashboard_cert_key,
-  Boolean $overwrite_dashboards           =  $puppet_metrics_dashboard::params::overwrite_dashboards,
-  String $overwrite_dashboards_file       =  $puppet_metrics_dashboard::params::overwrite_dashboards_file,
-  String $influx_db_service_name          =  $puppet_metrics_dashboard::params::influx_db_service_name,
-  Array[String] $influxdb_database_name   =  $puppet_metrics_dashboard::params::influxdb_database_name,
-  String $grafana_version                 =  $puppet_metrics_dashboard::params::grafana_version,
-  Integer $grafana_http_port              =  $puppet_metrics_dashboard::params::grafana_http_port,
-  String $influx_db_password              =  $puppet_metrics_dashboard::params::influx_db_password,
-  String $grafana_password                =  $puppet_metrics_dashboard::params::grafana_password,
-  Boolean $enable_kapacitor               =  $puppet_metrics_dashboard::params::enable_kapacitor,
-  Boolean $enable_chronograf              =  $puppet_metrics_dashboard::params::enable_chronograf,
-  Boolean $enable_telegraf                =  $puppet_metrics_dashboard::params::enable_telegraf,
-  Boolean $configure_telegraf             =  $puppet_metrics_dashboard::params::configure_telegraf,
-  Boolean $consume_graphite               =  $puppet_metrics_dashboard::params::consume_graphite,
-  Puppet_metrics_dashboard::HostList $master_list             = $puppet_metrics_dashboard::params::master_list,
-  Puppet_metrics_dashboard::HostList $puppetdb_list           = $puppet_metrics_dashboard::params::puppetdb_list,
-  Puppet_metrics_dashboard::HostList $postgres_host_list      = $puppet_metrics_dashboard::params::postgres_host_list,
-  Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = $puppet_metrics_dashboard::params::puppetdb_metrics,
-  Array[String] $influxdb_urls            =  $puppet_metrics_dashboard::params::influxdb_urls,
-  String $telegraf_db_name                =  $puppet_metrics_dashboard::params::telegraf_db_name,
-  String[2] $telegraf_agent_interval     =  $puppet_metrics_dashboard::params::telegraf_agent_interval,
-  String[2] $http_response_timeout       =  $puppet_metrics_dashboard::params::http_response_timeout,
-  String[2] $pg_query_interval           =  $puppet_metrics_dashboard::params::pg_query_interval,
-  ) inherits puppet_metrics_dashboard::params {
+  Boolean $add_dashboard_examples,
+  Boolean $manage_repos,
+  Boolean $use_dashboard_ssl,
+  String $dashboard_cert_file,
+  String $dashboard_cert_key,
+  Boolean $overwrite_dashboards,
+  String $overwrite_dashboards_file,
+  String $influx_db_service_name,
+  Array[String] $influxdb_database_name,
+  String $grafana_version,
+  Integer $grafana_http_port,
+  String $influx_db_password,
+  String $grafana_password,
+  Boolean $enable_kapacitor,
+  Boolean $enable_chronograf,
+  Boolean $enable_telegraf,
+  Boolean $configure_telegraf,
+  Boolean $consume_graphite,
+  Puppet_metrics_dashboard::HostList $master_list,
+  Puppet_metrics_dashboard::HostList $puppetdb_list,
+  Puppet_metrics_dashboard::HostList $postgres_host_list,
+  Array[String] $influxdb_urls,
+  String $telegraf_db_name,
+  String[2] $telegraf_agent_interval,
+  String[2] $http_response_timeout,
+  String[2] $pg_query_interval,
+  Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = puppet_metrics_dashboard::puppetdb_metrics(),
+  ) {
+  unless $facts['os']['family'] =~ /^(RedHat|Debian)$/ {
+    fail("${facts['os']['family']} installation not supported")
+  }
+
   if $manage_repos {
     contain puppet_metrics_dashboard::repos
     Class['puppet_metrics_dashboard::repos']

--- a/manifests/profile/compiler.pp
+++ b/manifests/profile/compiler.pp
@@ -11,8 +11,14 @@
 #
 # @param interval
 #   The frequency that telegraf will poll for metrics.  Defaults to '5s'
+#
+# @example Add telegraf to a master / compiler
+#   puppet_metrics_dashboard::profile::compiler{ $facts['networking']['fqdn']:
+#     timeout => '5s',
+#   }
+#
 define puppet_metrics_dashboard::profile::compiler (
-  String[2] $timeout                               = $puppet_metrics_dashboard::params::http_response_timeout,
+  String[2] $timeout                               = lookup('puppet_metrics_dashboard::http_response_timeout'),
   Variant[String,Tuple[String, Integer]] $compiler = $facts['networking']['fqdn'],
   Integer[1] $port                                 = 8140,
   String[2] $interval                              = '5s',

--- a/manifests/profile/master/postgres.pp
+++ b/manifests/profile/master/postgres.pp
@@ -8,9 +8,15 @@
 #
 # @param port
 #   The port that the postgres service listens on.  Defaults to 5432
+#
+# @example Add telegraf to a postgres server
+#   puppet_metrics_dashboard::profile::master::postgres{ $facts['networking']['fqdn']:
+#     query_interval => '10m',
+#   }
+#
 define puppet_metrics_dashboard::profile::master::postgres (
   Variant[String,Tuple[String, Integer]] $postgres_host = $facts['networking']['fqdn'],
-  String[2] $query_interval                             = $puppet_metrics_dashboard::params::pg_query_interval,
+  String[2] $query_interval                             = lookup('puppet_metrics_dashboard::pg_query_interval'),
   Integer[1] $port                                      = 5432,
   ){
 

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -4,6 +4,11 @@
 #   The FQDN of the host where telegraf runs.  
 #   Defaults to an empty string.  You can explicitly set this parameter or the class attempts to lookup which host has the puppet_metrics_dashboard class applied in PuppetDB.  If the parameter is not set and the lookup does not return anything we issue a warning.
 #
+# @example Allow access to PE-managed Postgres nodes
+#   class { 'puppet_metrics_dashboard::profile::master::postgres_access':
+#     telegraf_host => 'grafana-server.example.com',
+#   }
+#
 class puppet_metrics_dashboard::profile::master::postgres_access (
   String $telegraf_host = ''
 ){

--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -4,7 +4,8 @@
 #   Default timeout of http calls.  Defaults to 5 seconds
 #
 # @param puppetdb_metrics
-#   An array of hashes containing name / url pairs for each puppetdb metric.  See params.pp for defaults.
+#   An array of hashes containing name / url pairs for each puppetdb metric.
+#   See functions/puppetdb_metrics.pp for defaults.
 #
 # @param puppetdb_host
 #   The FQDN of the puppetdb host.  Defaults to the FQDN of the server where the profile is applied.
@@ -14,10 +15,17 @@
 #
 # @param interval
 #   The frequency that telegraf will poll for metrics.  Defaults to '5s'
+#
+# @example Add telegraf to a puppetdb node
+#   puppet_metrics_dashboard::profile::puppetdb{ $facts['networking']['fqdn']:
+#     timeout          => '5s',
+#     puppetdb_metrics => puppet_metrics_dashboard::puppetdb_metrics(), # this is the default value
+#   }
+#
 define puppet_metrics_dashboard::profile::puppetdb (
-  String[2] $timeout                                          = $puppet_metrics_dashboard::params::http_response_timeout,
+  String[2] $timeout                                          = lookup('puppet_metrics_dashboard::http_response_timeout'),
   Variant[String,Tuple[String, Integer]] $puppetdb_host       = $facts['networking']['fqdn'],
-  Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = $puppet_metrics_dashboard::params::puppetdb_metrics,
+  Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = puppet_metrics_dashboard::puppetdb_metrics(),
   Integer[1] $port                                            = 8081,
   String[2] $interval                                         = '5s',
   ){

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,6 @@ describe 'puppet_metrics_dashboard' do
 
       context 'with default values for all parameters' do
         it { is_expected.to contain_class('puppet_metrics_dashboard') }
-        it { is_expected.to contain_class('puppet_metrics_dashboard::params') }
         it { is_expected.to contain_class('puppet_metrics_dashboard::repos') }
         it { is_expected.to contain_class('puppet_metrics_dashboard::install') }
         it { is_expected.to contain_class('puppet_metrics_dashboard::config') }


### PR DESCRIPTION
This PR does the following:

- Switched from Hiera backend to standard function
- Created a function for determining the needed PuppetDB metrics based
  on PE version
- Removed the variable 'storage_metrics_db_queries' since it was not
  referenced anywhere.
- Updated the README and documentation in some manifests

This all stemmed from trying to solve the problem of having to define
the same values for parameter defaults in multiple places. The part of
this PR that addresses that exact problem is the new
`puppet_metrics_dashboard::puppetdb_metrics()` function. The rest of this
was just a by-product of getting to that solution.