### PR TITLE
Added ability to set default password

### DIFF
--- a/manifests/grafana.pp
+++ b/manifests/grafana.pp
@@ -30,11 +30,18 @@ class puppet_metrics_dashboard::grafana {
     }
   }
 
+  $_grafana_cfg = $grafana_cfg.merge({
+    'security' => {
+      'admin_user'     => 'admin',
+      'admin_password' => $puppet_metrics_dashboard::grafana_password,
+    }
+  })
+
   class { 'grafana':
     install_method      => 'repo',
     manage_package_repo => false,
     version             => $puppet_metrics_dashboard::grafana_version,
-    cfg                 => $grafana_cfg,
+    cfg                 => $_grafana_cfg,
     require             => Service[$puppet_metrics_dashboard::influx_db_service_name],
   }
 }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -39,7 +39,7 @@ describe 'puppet_metrics_dashboard::grafana' do
             .with_install_method('repo')
             .with_manage_package_repo(false)
             .with_version('5.1.4')
-            .with_cfg('server' => { 'http_port' => 3000 })
+            .with_cfg('server' => { 'http_port' => 3000 }, 'security' => { 'admin_user' => 'admin', 'admin_password' => 'admin' })
 
           case facts[:os]['family']
           when 'Debian'
@@ -73,12 +73,18 @@ describe 'puppet_metrics_dashboard::grafana' do
         # rubocop:disable RSpec/ExampleWording
         it 'should contain Class[grafana] with an https config' do
           is_expected.to contain_class('grafana')
-            .with_cfg('server' => {
-                        'http_port' => 3000,
-                        'protocol'  => 'https',
-                        'cert_file' => '/etc/grafana/testhost.example.com_cert.pem',
-                        'cert_key'  => '/etc/grafana/testhost.example.com_key.pem',
-                      })
+            .with_cfg(
+              'server' => {
+                'http_port' => 3000,
+                'protocol'  => 'https',
+                'cert_file' => '/etc/grafana/testhost.example.com_cert.pem',
+                'cert_key'  => '/etc/grafana/testhost.example.com_key.pem',
+              },
+              'security' => {
+                'admin_user'     => 'admin',
+                'admin_password' => 'admin',
+              },
+            )
         end
         # rubocop:enable RSpec/ExampleWording
       end


### PR DESCRIPTION
This is based on the docs here:

https://grafana.com/docs/installation/configuration/#admin-password

And fixes #24

Note that it only sets the admin password on build, but at least it sets it