### PR TITLE
Fix hung spec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .git/
-.vscode/
 .*.sw[op]
 .metadata
 .yardoc

--- a/.sync.yml
+++ b/.sync.yml
@@ -22,6 +22,7 @@ Gemfile:
     ':development':
       - gem: 'puppet-strings'
         version: '~> 2.0.0'
+      - gem: 'toml-rb'
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         platforms: ruby
@@ -38,6 +39,13 @@ Gemfile:
 
 spec/spec_helper.rb:
   mock_with: ':rspec'
+  spec_overrides:
+    - 'RSpec.configure do |c|'
+    - "  c.default_facter_version = '3.14.0'"
+    - "  c.after(:suite) do"
+    - "    RSpec::Puppet::Coverage.report!"
+    - "  end"
+    - "end"
 
 Rakefile:
   requires:

--- a/Gemfile
+++ b/Gemfile
@@ -23,12 +23,13 @@ group :development do
   gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "toml-rb", '= 1.1.2',                                      require: false, platforms: [:ruby]
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-strings", '~> 2.0.0',                              require: false
+  gem "toml-rb",                                                 require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,17 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['source'].match(%r{.*/([^/]*)})[1]
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.11.1",
-  "template-url": "pdk-default#1.11.1",
-  "template-ref": "1.11.1-0-g2ff8c24"
+  "pdk-version": "1.13.0",
+  "template-url": "pdk-default#1.13.0",
+  "template-ref": "1.13.0-0-g66e1443"
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::config' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/dashboards/graphite_spec.rb
+++ b/spec/classes/dashboards/graphite_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::dashboards::graphite' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:facts) do
         facts.merge(pe_server_version: '2017.2')
       end

--- a/spec/classes/dashboards/puppet_metrics_spec.rb
+++ b/spec/classes/dashboards/puppet_metrics_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::dashboards::puppet_metrics' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:facts) do
         facts.merge(pe_server_version: '2017.2')
       end

--- a/spec/classes/dashboards/telegraf_spec.rb
+++ b/spec/classes/dashboards/telegraf_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::dashboards::telegraf' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:facts) do
         facts.merge(pe_server_version: '2017.2')
       end

--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::dashboards' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::grafana' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'puppet_metrics_dashboard' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::install' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/post_start_configs_spec.rb
+++ b/spec/classes/post_start_configs_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::post_start_configs' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'puppet_metrics_dashboard::repos' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -54,7 +54,7 @@ describe 'puppet_metrics_dashboard::repos' do
             is_expected.to contain_apt__source('influxdb')
               .with(
                 'location' => 'https://repos.influxdata.com/debian',
-                'release' => 'jessie',
+                'release' => facts[:os]['distro']['codename'],
                 'repos' => 'stable',
               )
           end
@@ -72,7 +72,7 @@ describe 'puppet_metrics_dashboard::repos' do
             is_expected.to contain_apt__source('influxdb')
               .with(
                 'location' => 'https://repos.influxdata.com/ubuntu',
-                'release' => 'xenial',
+                'release' => facts[:os]['distro']['codename'],
                 'repos' => 'stable',
               )
           end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::service' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/telegraf/config_spec.rb
+++ b/spec/classes/telegraf/config_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::telegraf::config' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/telegraf/service_spec.rb
+++ b/spec/classes/telegraf/service_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::telegraf::service' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version}  on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_dashboard::telegraf' do
-  on_supported_os(facterversion: '3.7').each do |os, facts|
-    context "with facter 3.7 on #{os}" do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
       let(:node) do
         'testhost.example.com'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.before :each do
@@ -51,3 +56,9 @@ def ensure_module_defined(module_name)
 end
 
 # 'spec_overrides' from sync.yml will appear below this line
+RSpec.configure do |c|
+  c.default_facter_version = '3.14.0'
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!
+  end
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |c|
-  c.after(:suite) do
-    RSpec::Puppet::Coverage.report!
-  end
-end


### PR DESCRIPTION
    Prior to this commit, spec tests were hanging indefinitely. This commit
    fixes that issue by changing the way the facter version was specified in
    the spec testing. It sets up a default facter version which is
    compatible with the newer versions of `rspec-puppet-facts`. This change
    also updates PDK to 1.13.0 to apply the configuration change in the
    `.sync.yml`.

This resolves #74 