### PR TITLE
Change single quotes to double quotes

### DIFF
--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -10,7 +10,7 @@
 #   }
 #
 class puppet_metrics_dashboard::profile::master::postgres_access (
-  String $telegraf_host = ''
+  String $telegraf_host = ""
 ){
 
   ##If a value is not supplied, we try a lookup


### PR DESCRIPTION
Currently the default for $telegraf_host is two single quotes which is not compatible with the PE console.  Leaving this and not noticing when classifying in the console will bring postgresql down as they are not supported in pg_ident.conf file.