### PR TITLE
refactor documentation and simplify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Reference](#Reference)
 - [Limitations](#Limitations)
   - [Repository failure for InfluxDB packages](#Repository-failure-for-InfluxDB-packages)
-  - [PostgreSQL metrics collection with older versions of Telegraf](#PostgreSQL-metrics-collection-with-older versions-of-Telegraf)
+  - [PostgreSQL metrics collection with older versions of Telegraf](#PostgreSQL-metrics-collection-with-older-versions-of-Telegraf)
 - [Development](#Development)
 
 ## Description
@@ -134,6 +134,8 @@ node 'dashboard.example.com' {
   class { 'puppet_metrics_dashboard':
     add_dashboard_examples => true,
     overwrite_dashboards   => false,
+    configure_telegraf     => true,
+    enable_telegraf        => true,
     master_list            => ['master.example.com', ['compiler01.example.com', 9140], ['compiler02.example.com', 9140]],
     puppetdb_list          => ['puppetdb01.example.com', 'puppetdb02.example.com'],
     postgres_host_list     => ['postgres01.example.com', 'postgres02.example.com'],
@@ -186,6 +188,8 @@ node 'dashboard.example.com' {
   class { 'puppet_metrics_dashboard':
     add_dashboard_examples => true,
     overwrite_dashboards   => false,
+    configure_telegraf     => true,
+    enable_telegraf        => true,
     consume_graphite       => true,
     influxdb_database_name => ['telegraf', 'graphite', 'puppet_metrics'],
   }

--- a/README.md
+++ b/README.md
@@ -2,220 +2,287 @@
 
 - [Description](#Description)
 - [Setup](#Setup)
-  - [Upgrade notes, breaking changes in v2](#Upgrade-notes-breaking-changes-in-v2)
+  - [Upgrade notes](#Upgrade-notes)
   - [Determining where Telegraf runs](#Determining-where-Telegraf-runs)
-  - [Requirements](#requirements)
-  - [Beginning with puppet_metrics_dashboard](#Beginning-with-puppet_metrics_dashboard)
-    - [Minimal configuration](#Minimal-configuration)
+  - [Requirements](#Requirements)
 - [Usage](#Usage)
-  - [To install example dashboards and use the Telegraf collection method (default)](#To-install-example-dashboards-and-use-the-Telegraf-collection-method-default)
-  - [Configure Telegraf for one or more masters / PuppetDB nodes / Postgres nodes](#Configure-Telegraf-for-one-or-more-masters--PuppetDB-nodes--Postgres-nodes)
-  - [Enable Graphite support](#Enable-Graphite-support)
-  - [Enable Telegraf, Graphite, and Archive (puppet_metrics)](#Enable-Telegraf-Graphite-and-Archive-puppet_metrics)
+  - [Configure a Monolithic Master and a Dashboard node](#Configure-a-Monolithic-Master-and-a-Dashboard-node)
+  - [Manual configuration of a complex Puppet Infrastructure](#Manual-configuration-of-a-complex-Puppet-Infrastructure)
+  - [Configure Graphite](#Configure-Graphite)
+  - [Configure Telegraf, Graphite, and Archive](#Configure-Telegraf,-Graphite,-and-Archive)
+  - [Allow Telegraf to access PE-PostgreSQL](#Allow-Telegraf-to-access-PE-PostgreSQL)
   - [Enable SSL](#Enable-SSL)
-  - [Allow access to PE-managed Postgres nodes with the following class](#Allow-access-to-PE-managed-Postgres-nodes-with-the-following-class)
   - [Profile defined types](#Profile-defined-types)
-    - [Note on using the defined types](#Note-on-using-the-defined-types)
   - [Other possibilities](#Other-possibilities)
 - [Reference](#Reference)
 - [Limitations](#Limitations)
-  - [Repo failure for InfluxDB packages](#Repo-failure-for-InfluxDB-packages)
-  - [Postgres metrics collection requires Telegraf version 1.9.1 or later](#Postgres-metrics-collection-requires-Telegraf-version-191-or-later)
+  - [Repository failure for InfluxDB packages](#Repository-failure-for-InfluxDB-packages)
+  - [PostgreSQL metrics collection with older versions of Telegraf](#PostgreSQL-metrics-collection-with-older versions-of-Telegraf)
 - [Development](#Development)
 
 ## Description
 
-This module is used to configure Grafana and InfluxDB to consume metrics from Puppet services.
-By default the metrics collection is done by [Telegraf](https://github.com/influxdata/telegraf).
+This module is used to configure Telegraf, InfluxDB, and Grafana, and collect, store, and display metrics collected from Puppet services.
+By default, those components are installed on a separate Dashboard node by applying the base class of this module to that node.
+That class will automatically query PuppetDB for Puppet Infrastructure nodes (Masters, PuppetDB hosts, PostgreSQL hosts) or you can specify them via associated class parameters.
+It is not recommended to apply the base class of this module to one of your Puppet Infrastructure nodes.
 
-These services can all run on a single server by applying the base class.  You also have the option
-to use the [included defined types](#profile-defined-types) to configure Telegraf on each of your Puppet infrastructure components
-(master, compilers, PuppetDB, Postgres server) and the metrics will be stored on another server
-running Grafana and InfluxDB.  In environments where there is an existing Grafana / InfluxDB
-instance, the later option is recommended. See [Determining where Telegraf runs](#determining-where-telegraf-runs) for further
-details.
+You have the option to use the [included defined types](#profile-defined-types) to configure Telegraf to run on each Puppet Infrastructure node,
+with the metrics being stored and displayed by another node running InfluxDB and Grafana.  
+In environments where there is an existing InfluxDB/Grafana installation, this option is recommended.
+See [Determining where Telegraf runs](#determining-where-telegraf-runs) for details.
 
-You have the option of collecting metrics using any or all of these methods:
+You have the option of collecting metrics using any or all of the following methods:
 
-- Through Telegraf, which polls several of Puppet's metrics endpoints (recommended)
-- Through Archive files from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
-- Natively, via Puppetserver's [built-in graphite support](https://puppet.com/docs/pe/2019.0/getting_started_with_graphite.html#task-7933)
+- Via Telegraf, which polls Puppet service endpoints (default, recommended)
+- Via Puppet Server's [built-in Graphite support](https://puppet.com/docs/pe/latest/getting_started_with_graphite.html) (Section: Enabling Puppet Server's Graphite support)
+- Via Archive files imported from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
 
 ## Setup
 
-### Upgrade notes, breaking changes in v2
+### Upgrade notes
 
-Version 2 and up now requires the toml-rb gem installed on the master
+* Version 2 and up now requires the `toml-rb` gem installed on the Master and any/all Compilers.
+* The `puppet_metrics_dashboard::profile::postgres` class is deprecated in favor of the `puppet_metrics_dashboard::profile::master::postgres_access` class.
+* Parameters `telegraf_agent_interval` and `http_response_timeout` were previously Integers but are now Strings. The value should match a time interval, such as `5s`, `10m`, or `1h`.
+* `influxdb_urls` was previously a String, but is now an Array.
 
-The `puppet_metrics_dashboard::profile::postgres` class is now deprecated and you should use the `puppet_metrics_dashboard::profile::Master::postgres_access` class instead.
-
-Parameters `telegraf_agent_interval` and `http_response_timeout` were previously integers but are now strings.  The value should match a time interval, such as `5s`, `10m`, or `1h`.
-
-`influxdb_urls` was previously a string, it should now be an array.
-
-Previous versions of this module put several `[[inputs.httpjson]]` entries in
-`/etc/telegraf/telegraf.conf`. These entries should be removed now as all
-module-specific settings now reside in individual files within
-`/etc/telegraf/telegraf.d/`. Telegraf will continue to work if you do not remove them, however, the old
-`[[inputs.httpjson]]` will not be updated going forward.
+Previous versions of this module added several `[[inputs.httpjson]]` entries in `/etc/telegraf/telegraf.conf`.
+These entries should be removed, as all module-specific settings now reside in individual files within `/etc/telegraf/telegraf.d/`.
+Telegraf will continue to work if you do not remove them, however, the old `[[inputs.httpjson]]` will not be updated going forward.
 
 ### Determining where Telegraf runs
 
-Telegraf can run on the Grafana server or on each Puppet infrastructure node.  To configure Telegraf to run on the same host that
-Grafana runs on, use the `puppet_metrics_dashboard` class and the parameters: `master_list`, `puppetdb_list` and `postgres_host_list`.  These parameters determine which hosts that Telegraf polls.
+Telegraf can be configured to run on the Dashboard node, or on each Puppet Infrastructure node.
+By default, this module configures Telegraf on the Dashboard node by querying PuppetDB to identify each Puppet Infrastructure node.
+To manually configure Telegraf on the Dashboard node, define the following `puppet_metrics_dashboard` class parameters: `master_list`, `puppetdb_list` and `postgres_host_list`.
 
-To configure Telegraf to run on each Puppet infrastructure node, use the corresponding profiles for those hosts.  See [Profile defined types](#profile-defined-types).  The `puppet_metrics_dashboard` class is still applied to a separate host to setup Grafana and InfluxDB and the profile classes configure Telegraf when applied to your Puppet infrastructure hosts.
+To configure Telegraf to run on each Puppet Infrastructure node, use the corresponding profiles for those nodes.
+See [Profile defined types](#profile-defined-types).
+Apply the `puppet_metrics_dashboard` class to the Dashboard node to configure InfluxDB and Grafana, and apply the profile classes on each Puppet Infrastructure node to configure Telegraf.
 
 ### Requirements
 
-This module **requires** the [toml-rb](https://github.com/eMancu/toml-rb) gem.  You can install the gem using puppet's native gem provider, [puppetserver_gem](https://forge.puppetlabs.com/puppetlabs/puppetserver_gem), [pe_gem](https://forge.puppetlabs.com/puppetlabs/pe_gem), [pe_puppetserver_gem](https://forge.puppetlabs.com/puppetlabs/pe_puppetserver_gem), or manually using one of the following methods:
-```
-  # apply on puppet-master
-  gem install toml-rb
-  # PE apply
-  /opt/puppetlabs/puppet/bin/gem install toml-rb
-  # AIO or PE puppetserver
-  /opt/puppet/bin/puppetserver gem install toml-rb
-```
+The [toml-rb](https://github.com/emancu/toml-rb) gem is a requirement of the `puppet-telegraf` module, and needs to be installed in Puppet Server on the Master and any/all Compilers.
 
-### Beginning with puppet_metrics_dashboard
-
-#### Minimal configuration
-
-Configures Grafana, InfluxDB, and Telegraf, with an InfluxDB datasource and a database called "puppet_metrics"
+Apply the following class to the Master and any/all Compilers to install the gem.
 
 ```puppet
-include puppet_metrics_dashboard
+node 'master.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
+node 'compiler.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
 ```
+
+Or, you can apply the `puppet_metrics_dashboard::profile::master::install` class to the `PE Master` Node Group, if using Puppet Enterprise. 
+
+Or, you can manually install the gem using the following command.
+
+```bash
+puppetserver gem install toml-rb
+```
+
+Restart the Puppet Server service after manually installing the gem.
+
+If you are configuring the Dashboard node via a `puppet apply` workflow, you will need to install the gem into Puppet on that host.
 
 ## Usage
 
-### To install example dashboards and use the Telegraf collection method (default)
+### Configure a Monolithic Master and a Dashboard node
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  add_dashboard_examples => true,
+node 'master.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+  include puppet_metrics_dashboard::profile::master::postgres_access
+}
+
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    add_dashboard_examples => true,
+    overwrite_dashboards   => false,
+  }
 }
 ```
 
-> `add_dashboard_examples` enforces state on the dashboards. Remove this later if you want to make edits to the examples or add the `overwrite_dashboards` parameter to disable overwriting the dashboards after the first run.
+This will configure Telegraf, InfluxDB, and Grafana on the Dashboard node, and allow Telegraf on that host to access PostgreSQL on the Monolithic Master.
+
+Note that the `add_dashboard_examples` parameter enforces state on the example dashboards.
+Setting the `overwrite_dashboards` parameter to `true` disables overwriting your modifications (if any) to the example dashboards.
+
+### Manual configuration of a complex Puppet Infrastructure
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  add_dashboard_examples => true,
-  overwrite_dashboards   => false,
+node 'master.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
+node 'compiler01.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
+node 'compiler02.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
+node 'postgres01.example.com' {
+  include puppet_metrics_dashboard::profile::master::postgres_access
+}
+node 'postgres02.example.com' {
+  include puppet_metrics_dashboard::profile::master::postgres_access
+}
+
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    add_dashboard_examples => true,
+    overwrite_dashboards   => false,
+    master_list            => ['master.example.com', ['compiler01.example.com', 9140], ['compiler02.example.com', 9140]],
+    puppetdb_list          => ['puppetdb01.example.com', 'puppetdb02.example.com'],
+    postgres_host_list     => ['postgres01.example.com', 'postgres02.example.com'],
+  }
+}
+# Alternate ports are configured using a pair of: [host_name, port_number]
+```
+
+Note that the defaults for this module's class parameters are defined in its `data/common.yaml` directory.
+
+The `*_list` parameters can be defined in the class declaration, or elsewhere in Hiera. For example:
+
+```
+puppet_metrics_dashboard::master_list:
+  - "master.example.com"
+  - ["compiler01.example.com", 9140]
+  - ["compiler02.example.com", 9140]
+puppet_metrics_dashboard::puppetdb_list:
+  - "puppetdb01.example.com"
+  - "puppetdb02.example.com"
+puppet_metrics_dashboard::postgres_host_list:
+  - "postgres01.example.com"
+  - "postgres02.example.com"
+```
+
+### Configure Graphite
+
+```puppet
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    add_dashboard_examples => true,
+    overwrite_dashboards   => false,
+    consume_graphite       => true,
+    influxdb_database_name => ['graphite'],
+    master_list            => ['master', 'master02'],
+  }
 }
 ```
 
-### Configure Telegraf for one or more masters / PuppetDB nodes / Postgres nodes
+* This method requires enabling Graphite on the Masters, as described [here](https://puppet.com/docs/pe/latest/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support).
+The hostnames that you use in `master_list` must match the value(s) that you used for `metrics_server_id` in the `puppet_enterprise::profile::master` class.
+You must use hostnames rather than fully-qualified domain names (no dots) both in this class and in the  `puppet_enterprise::profile::master` class.
+
+### Configure Telegraf, Graphite, and Archive
+
+Archive refers to files imported from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module.
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  master_list         => ['master1.com',
-                          # Alternate ports may be configured using
-                          # a pair of: [hostname, port_number]
-                          ['master2.com', 9140]],
-  puppetdb_list       => ['puppetdb1','puppetdb2'],
-  postgres_host_list  => ['postgres01','postgres02'],
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    add_dashboard_examples => true,
+    overwrite_dashboards   => false,
+    consume_graphite       => true,
+    influxdb_database_name => ['telegraf', 'graphite', 'puppet_metrics'],
+  }
 }
 ```
 
-### Enable Graphite support
+### Allow Telegraf to access PE-PostgreSQL
+
+The following class is required to be applied to the Master (or the PE Database node if using external PostgreSQL) for collection of PostgreSQL metrics via Telegraf.
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  add_dashboard_examples => true,
-  consume_graphite       => true,
-  influxdb_database_name => ["graphite"],
-  master_list            => ["master01.example.com","master02.org"],
+node 'master.example.com' {
+  class { 'puppet_metrics_dashboard::profile::master::postgres_access':
+    telegraf_host => 'grafana-server.example.com',
+  }
 }
 ```
 
-* This method requires enabling on the master side as described [here](https://puppet.com/docs/pe/latest/puppet_server_metrics/getting_started_with_graphite.html#enabling-puppet-server-graphite-support).  The hostname(s) that you use in `master_list` should match the value(s) that you used for `metrics_server_id` in the `puppet_enterprise::profile::master` class.
+The `telegraf_host` parameter is optional. 
+By default, the class will query PuppetDB for Dashboard nodes (with the `puppet_metrics_dashboard` class applied) and use the `certname` of the first node in the results.
+If the PuppetDB lookup fails to find a Dashboard node, and you do not specify `telegraf_host` then the class outputs a warning.
 
-### Enable Telegraf, Graphite, and Archive (puppet_metrics)
+Refer to [Issue 72](https://github.com/puppetlabs/puppet_metrics_dashboard/issues/72) if the above generates the following error:
 
-```puppet
-class { 'puppet_metrics_dashboard':
-  add_dashboard_examples => true,
-  influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
-  consume_graphite       => true,
-}
 ```
+Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef (file: /opt/puppetlabs/puppet/modules/pe_postgresql/manifests/server/role.pp, line: 66, column: 6) (file: /etc/puppetlabs/code/environments/production/modules/puppet_metrics_dashboard/manifests/profile/master/postgres_access.pp, line: 42) on node master.example.com
+```
+
+A workaround for that error is to apply the `puppet_metrics_dashboard::profile::master::postgres_access` class to the `PE Database` Node Group in the Console, if using Puppet Enterprise. 
 
 ### Enable SSL
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  use_dashboard_ssl => true,
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    use_dashboard_ssl => true,
+  }
 }
 ```
 
-By default, this will create a set of certificates in `/etc/grafana` that are based on Puppet's agent certificates. You can also specify a different location by passing the variables below, but managing the certificate content or supplying your own certificates isn't yet supported.
+By default, this will create a set of certificates in `/etc/grafana` that are based on the Dashboard node's Puppet agent certificates.
+You can also specify different files by defining the `dashboard_cert_file` and `dashboard_cert_key` parameters, but managing certificate content or supplying your own certificates is unsupported by this module.
 
-`dashboard_cert_file` `dashboard_cert_key`
-
-_Note:_ Enabling SSL on Grafana will not allow for running on privileged ports such as `443`. To enable this capability you can use the suggestions documented in [this Grafana documentation](http://docs.grafana.org/installation/configuration/#http-port)
-
-### Allow access to PE-managed Postgres nodes with the following class
-
-This is required for collection of Postgres metrics.  The class should be applied to the master (or Postgres server if using external Postgres).
-
-```puppet
-class { 'puppet_metrics_dashboard::profile::master::postgres_access':
-  telegraf_host => 'grafana-server.example.com',
-}
-```
-
-`telegraf_host` is optional.  If you do not specify it, the class will look for a node with the `puppet_metrics_dashboard` class applied in PuppetDB and use the `certname` of the first host returned.  If the PuppetDB lookup fails and you do not specify `telegraf_host` then the class outputs a warning.
+Note that enabling SSL on Grafana will not allow for running on privileged ports such as `443`.
+To enable that capability, use the suggestions documented in [the Grafana documentation](http://docs.grafana.org/installation/configuration/#http-port)
 
 ### Profile defined types
 
-The module includes defined types that you can use with an existing Grafana implementation. See [REFERENCE.md](REFERENCE.md) for example usage.
+The module includes defined types that you can use with an existing Grafana implementation.
+See [REFERENCE.md](REFERENCE.md) for example usage.
 
-#### Note on using the defined types
-
-Because of the way that the Telegraf module works, these examples will overwrite any configuration in `telegraf.conf` if it is *not* already puppet-managed.  See the [puppet-telegraf documentation](https://forge.puppet.com/puppet/telegraf#usage) on how to manage this file and add important settings.
+Note that because of the way that the Telegraf module works, these examples will overwrite any configuration in `telegraf.conf` if it is *not* already managed by Puppet.
+See the [puppet-telegraf documentation](https://forge.puppet.com/puppet/telegraf#usage) on how to manage that file and add other settings.
 
 ### Other possibilities
 
-Configure the passwords for the InfluxDB and enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components.
+Configure the password for InfluxDB , enable additional [TICK Stack](https://www.influxdata.com/time-series-platform/) components, and customize Grafana.
 
 ```puppet
-class { 'puppet_metrics_dashboard':
-  influx_db_password  => 'secret',
-  grafana_http_port   => 8080,
-  grafana_version     => '4.5.2',
-  enable_chronograf   => true,
-  enable_kapacitor    => true,
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    influx_db_password  => 'secret',
+    enable_chronograf   => true,
+    enable_kapacitor    => true,
+    grafana_http_port   => 3333,
+    grafana_version     => '6.5.2',
+  }
 }
 ```
 
 ## Reference
 
-This module is documented via
-`pdk bundle exec puppet strings generate --format markdown`.
-Please see [REFERENCE.md](REFERENCE.md) for more info.
+This module is documented via `pdk bundle exec puppet strings generate --format markdown`.
+Please refer to [REFERENCE.md](REFERENCE.md) for more information.
 
 ## Limitations
 
-### Repo failure for InfluxDB packages
+### Repository failure for InfluxDB packages
 
-When installing InfluxDB on CentOS/RedHat 6 or 7 you may encounter the following error message. This is due to a mismatch in the ciphers available on the local OS and on the InfluxDB repo.
+When installing InfluxDB on CentOS/RedHat 6/7 you may encounter the following error message.
 
 ```puppet
 Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
-Error: /Stage[main]/Pe_metrics_dashboard::Telegraf/Package[telegraf]/ensure: change from purged to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
+Error: /Stage[main]/Puppet_metrics_dashboard::Telegraf/Package[telegraf]/ensure: change from purged to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install telegraf' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: influxdb. Please verify its path and try again
 ```
 
-To rectify the issue, please update `nss` and `curl` on the affected system.
+This is due to a mismatch in the ciphers available in the operating system and on the InfluxDB repository.
+To resolve this issue, update `nss` and `curl` on the Dashboard node.
 
 ```bash
 yum install curl nss --disablerepo influxdb
 ```
 
-### Postgres metrics collection requires Telegraf version 1.9.1 or later
+### PostgreSQL metrics collection with older versions of Telegraf
+
+PostgreSQL metrics collection requires Telegraf version 1.9.1 or later.
 
 ## Development
 
-Please see CONTRIBUTING.md
+Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,8 +5,8 @@
 
 ### Public Classes
 
-* [`puppet_metrics_dashboard`](#puppet_metrics_dashboard): Installs and configures Grafana with InfluxDB for monitoring Puppet infrastructure.
-* [`puppet_metrics_dashboard::profile::master::postgres_access`](#puppet_metrics_dashboardprofilemasterpostgres_access): Apply this class to a PE-managed postgres instance to allow access from telegraf
+* [`puppet_metrics_dashboard`](#puppet_metrics_dashboard): Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics
+* [`puppet_metrics_dashboard::profile::master::postgres_access`](#puppet_metrics_dashboardprofilemasterpostgres_access): Apply this class to a PE PostgreSQL node to allow access by Telegraf.
 * [`puppet_metrics_dashboard::profile::postgres`](#puppet_metrics_dashboardprofilepostgres): This class is deprecated.  Please use the Puppet_metrics_dashboard::Profile::Master::Postgres_access class.
 
 ### Private Classes
@@ -34,86 +34,69 @@
 
 ## Functions
 
+* [`puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile`](#puppet_metrics_dashboardlocalhost_or_hosts_with_pe_profile): 
 * [`puppet_metrics_dashboard::puppetdb_metrics`](#puppet_metrics_dashboardpuppetdb_metrics): function used to determine the set of needed PuppetDB metrics based on PE version
 
 ## Classes
 
 ### puppet_metrics_dashboard
 
-The puppet_metrics_dashboard module installs and configures an InfluxDB stack
-monitor the Puppet infrastructure components.
+Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics.
+Refer to `data/common.yaml` for additional parameter defaults.
 
 #### Examples
 
-##### Default Configuration
-
-```puppet
-include puppet_metrics_dashboard
-```
-
-##### Configure Telegraf on a list of masters and PuppetDB servers
+##### Grafana with no login
 
 ```puppet
 class { 'puppet_metrics_dashboard':
-  configure_telegraf  => true,
-  enable_telegraf     => true,
-  master_list         => ['master1.com',
-                          # Alternate ports may be configured using
-                          # a list of: `[hostname, port_number]`
-                          ['master2.com', 9140]],
-  puppetdb_list       => ['puppetdb1',
-                          ['puppetdb2', 8100]],
+  grafana_config => {
+    'users'          => {
+      'allow_sign_up' => false,
+    },
+    'auth.anonymous' => {
+      'enabled' => true,
+    },
+  },
 }
 ```
 
-##### Install example dashboards for all of the collection methods
+##### Configure Telegraf to collect metrics from a list of Masters, PuppetDB, and PostgreSQL servers
 
 ```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
-  influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
+  overwrite_dashboards   => false,
+  configure_telegraf     => true,
+  enable_telegraf        => true,
+  master_list            => ['master.example.com', ['compiler01.example.com', 9140], ['compiler02.example.com', 9140]],
+  puppetdb_list          => ['puppetdb01.example.com', 'puppetdb02.example.com'],
+  postgres_host_list     => ['postgres01.example.com', 'postgres02.example.com'],
 }
 ```
 
-##### Configure telegraf for one or more masters / puppetdb nodes
-
-```puppet
-class { 'puppet_metrics_dashboard':
-  configure_telegraf  => true,
-  enable_telegraf     => true,
-  master_list         => ['master1.com','master2.com'],
-  puppetdb_list       => ['puppetdb1','puppetdb2'],
-}
-```
-
-##### Enable Graphite support
+##### Configure Graphite to accept metrics from a list of Masters
 
 ```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
+  overwrite_dashboards   => false,
   consume_graphite       => true,
-  influxdb_database_name => ["graphite"],
-  master_list            => ["master01.example.com","master02.org"],
+  influxdb_database_name => ['graphite'],
+  master_list            => ['master', 'master02'],
 }
 ```
 
-##### Enable Telegraf, Graphite, and Archive
+##### Configure Telegraf, Graphite, and Archive
 
 ```puppet
 class { 'puppet_metrics_dashboard':
   add_dashboard_examples => true,
-  influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
+  overwrite_dashboards   => false,
   consume_graphite       => true,
   configure_telegraf     => true,
   enable_telegraf        => true,
-}
-```
-
-##### Enable SSL
-
-```puppet
-class { 'puppet_metrics_dashboard':
-  use_dashboard_ssl => true,
+  influxdb_database_name => ['telegraf', 'graphite', 'puppet_metrics'],
 }
 ```
 
@@ -121,237 +104,241 @@ class { 'puppet_metrics_dashboard':
 
 The following parameters are available in the `puppet_metrics_dashboard` class.
 
-##### `add_dashboard_examples`
-
-Data type: `Boolean`
-
-Whether to add the Grafana dashboard example dashboards for the configured InfluxDB databases.
-Valid values are `true`, `false`. Defaults to `false`.
-_Note_: These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
-
 ##### `manage_repos`
 
 Data type: `Boolean`
 
-Whether or not to setup yum / apt repositories for the dependent packages
-Valid values are `true`, `false`. Defaults to `true`
+Whether to configure apt / yum repositories for required packages.
+
+##### `add_dashboard_examples`
+
+Data type: `Boolean`
+
+Whether to add the example Grafana dashboards for the configured InfluxDB databases. Defaults to `false`.
+_Note_: These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
+
+##### `overwrite_dashboards`
+
+Data type: `Boolean`
+
+Whether to overwrite the example Grafana dashboards. Defaults to `true`
+This parameter disables overwriting the example Grafana dashboards.
+It takes effect after the second Puppet run, and populates a `overwrite_dashboards_disabled` fact.
+Only used when `add_dashboard_examples` is `true`.
+
+##### `enable_chronograf`
+
+Data type: `Boolean`
+
+Whether to install chronograf. Defaults to `false`
+No configuration of chronograf is included at this time.
+
+##### `enable_kapacitor`
+
+Data type: `Boolean`
+
+Whether to install kapacitor. Defaults to `false`
+No configuration of kapacitor is included at this time.
+
+##### `enable_telegraf`
+
+Data type: `Boolean`
+
+Whether to install telegraf. Defaults to `true`
+No configuration is done unless `configure_telegraf` is set to `true`.
+
+##### `configure_telegraf`
+
+Data type: `Boolean`
+
+Whether to configure the Telegraf service. Defaults to `true`
+This parameter enables and configures Telegraf to query the `*_list` hosts for metrics.
+Metrics will be stored in the `telegraf` database in InfluxDb.
+Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
+Only used when `enable_telegraf` is `true`.
+
+##### `consume_graphite`
+
+Data type: `Boolean`
+
+Whether to enable the InfluxDB Graphite plugin. Defaults to `false`
+This parameter enables the Graphite plugin for InfluxDB to allow for consuming Graphite metrics.
+Ensure `influxdb_database_name` contains `graphite` when using this parameter.
+_Note:_ To consume metrics sent from Puppet Server, this must to be set to `true`.
+
+##### `influxdb_database_name`
+
+Data type: `Array[String]`
+
+An Array of databases that should be created in InfluxDB.
+Valid values are `telegraf`, `graphite`, `puppet_metrics`, and any other string. Defaults to `["telegraf"]`
+Each database in the array will be created in InfluxDB.
+`telegraf`, `graphite`, and `puppet_metrics` are specially named and will be used with their associated metric collection method.
+Any other database name will be created, but not associated with components in this module.
+
+##### `influxdb_urls`
+
+Data type: `Array[String]`
+
+An Array containing urls defining InfluxDB instances for Telegraf.
+
+##### `influx_db_service_name`
+
+Data type: `String`
+
+Name of the InfluxDB service used by the operating system.
+
+##### `influx_db_password`
+
+Data type: `String`
+
+The password for the InfluxDB `admin` user.
+Defaults to `puppet`
+
+##### `telegraf_db_name`
+
+Data type: `String`
+
+The InfluxDB database where Telegraf metrics are stored.
+
+##### `http_response_timeout`
+
+Data type: `String[2]`
+
+Timeout for Telegraf HTTP requests. Defaults to `5s`
+
+##### `telegraf_agent_interval`
+
+Data type: `String[2]`
+
+Frequency of Telegraf HTTP queries for metrics. Defaults to `5s`
+
+##### `pg_query_interval`
+
+Data type: `String[2]`
+
+Frequency of Telegraf PostgreSQL queries for metrics. Defaults to `10m`
+
+##### `use_dashboard_ssl`
+
+Data type: `Boolean`
+
+Whether to enable SSL in Grafana.
+Valid values are `true`, `false`. Defaults to `false`
 
 ##### `dashboard_cert_file`
 
 Data type: `String`
 
 The location of the Grafana certficiate.
-Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
-Only used when configuring `use_dashboard_ssl` is true.
+Defaults to `/etc/grafana/${clientcert}_cert.pem`
+Only used when `use_dashboard_ssl` is `true`.
 
 ##### `dashboard_cert_key`
 
 Data type: `String`
 
 The location of the Grafana private key.
-Defaults to `"/etc/grafana/${clientcert}_key.pem"`
-Only used when configuring `use_dashboard_ssl` is true.
-
-##### `configure_telegraf`
-
-Data type: `Boolean`
-
-Whether to configure the telegraf service.
-Valid values are `true`, `false`. Defaults to `true`
-This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored
-in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
-_Note:_ This parameter is only used if `enable_telegraf` is set to true.
-
-##### `consume_graphite`
-
-Data type: `Boolean`
-
-Whether to enable the InfluxDB Graphite plugin.
-Valid values are `true`, `false`. Defaults to `false`
-This parameter enables the Graphite plugin for InfluxDB to allow for injesting Graphite metrics. Ensure `influxdb_database_name`
-contains `graphite` when using this parameter.
-_Note:_ If using Graphite metrics from the Puppet Master, this needs to be set to `true`.
+Defaults to `/etc/grafana/${clientcert}_key.pem`
+Only used when `use_dashboard_ssl` is `true`.
 
 ##### `grafana_http_port`
 
 Data type: `Integer`
 
-The port to run Grafana on.
+The port for the Grafana web interface.
 Valid values are Integers from `1024` to `65536`. Defaults to `3000`
-The grafana port for the web interface. This should be a nonprivileged port (above 1024).
+This should be a nonprivileged port (above 1024).
 
 ##### `grafana_password`
 
 Data type: `String`
 
-The password for the Grafana admin user.
-Defaults to `'admin'`
+The password for the Grafana `admin` user.
+Defaults to `admin`
 
 ##### `grafana_version`
 
 Data type: `String`
 
-The grafana version to install.
-Valid values are String versions of Grafana. Defaults to `'4.5.2'`
-
-##### `influxdb_database_name`
-
-Data type: `Array[String]`
-
-An array of databases that should be created in InfluxDB.
-Valid values are 'puppet_metrics','telegraf', 'graphite', and any other string. Defaults to `['puppet_metrics']`
-Each database in the array will be created in InfluxDB. 'puppet_metrics','telegraf', and 'graphite' are specially named and will
-be used with their associated metric collection method. Any other database name will be created, but not utilized with
-components in this module.
-
-##### `influx_db_password`
-
-Data type: `String`
-
-The password for the InfluxDB admin user.
-Defaults to `'puppet'`
-
-##### `enable_kapacitor`
-
-Data type: `Boolean`
-
-Whether to install kapacitor.
-Valid values are `true`, `false`. Defaults to `false`
-Install kapacitor. No configuration of kapacitor is included at this time.
-
-##### `enable_chronograf`
-
-Data type: `Boolean`
-
-Whether to install chronograf.
-Valid values are `true`, `false`. Defaults to `false`
-Installs chronograf. No configuration of chronograf is included at this time.
-
-##### `enable_telegraf`
-
-Data type: `Boolean`
-
-Whether to install telegraf.
-Valid values are `true`, `false`. Defaults to `false`
-Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
-
-##### `master_list`
-
-Data type: `Puppet_metrics_dashboard::HostList`
-
-A list of Puppet Master servers that Telegraf will be configured to
-collect metrics from. Entries in the list may be:
-  - A single string that contains a hostname or IP address.
-    The module will use a default port number of 8140.
-  - A list of length two, where the first entry is a string that
-    contains a hostname or IP address and the second entry is an
-    integer that specifies the port number.
-Defaults to `[$trusted['certname']]`
-
-##### `puppetdb_metrics`
-
-Data type: `Puppet_metrics_dashboard::Puppetdb_metric`
-
-An array of hashes containing name / url pairs for each puppetdb metric.
-See functions/puppetdb_metrics.pp for defaults.
-
-Default value: puppet_metrics_dashboard::puppetdb_metrics()
-
-##### `influxdb_urls`
-
-Data type: `Array[String]`
-
-An array for telegraf's config defining where influxdb instances are
-
-##### `telegraf_db_name`
-
-Data type: `String`
-
-The database in influxdb where telefraf metrics are stored
-
-##### `telegraf_agent_interval`
-
-Data type: `String[2]`
-
-How often the telefraf agent queries for metrics.  Defaults to "5s"
-
-##### `http_response_timeout`
-
-Data type: `String[2]`
-
-How long to wait for the queries by telegraf to finish before giving up. Defaults to "5s"
-
-##### `pg_query_interval`
-
-Data type: `String[2]`
-
-How often postgres queries will run when monitoring a postgres host. Defaults to "10m"
-
-##### `overwrite_dashboards`
-
-Data type: `Boolean`
-
-Whether to overwrite the example Grafana dashboards.
-Valid values are `true`, `false`. Defaults to `false`
-This paramater disables overwriting the example Grafana dashboards. It takes effect after the second Puppet run and popultes the
-`overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
-
-##### `puppetdb_list`
-
-Data type: `Puppet_metrics_dashboard::HostList`
-
-A list of PuppetDB servers that Telegraf will be configured to
-collect metrics from. Entries in the list may be:
-  - A single string that contains a hostname or IP address.
-    The module will use a default port number of 8081.
-  - A list of length two, where the first entry is a string that
-    contains a hostname or IP address and the second entry is an
-    integer that specifies the port number.
-Defaults to `[$trusted['certname']]`
-
-##### `postgres_host_list`
-
-Data type: `Puppet_metrics_dashboard::HostList`
-
-A list of PostgreSQL servers that Telegraf will be configured to
-collect metrics from. Entries in the list may be:
-  - A single string that contains a hostname or IP address.
-    The module will use a default port number of 5432.
-  - A list of length two, where the first entry is a string that
-    contains a hostname or IP address and the second entry is an
-    integer that specifies the port number.
-Defaults to `[$trusted['certname']]`
-
-##### `use_dashboard_ssl`
-
-Data type: `Boolean`
-
-Whether to enable SSL on Grafana.
-Valid values are `true`, `false`. Defaults to `false`
+The version of Grafana to install.
+Valid values are String versions of Grafana.
 
 ##### `overwrite_dashboards_file`
 
 Data type: `String`
 
-File in use to populate the overwrite_dashboards fact
+File used to populate the `overwrite_dashboards` fact.
 
-##### `influx_db_service_name`
+##### `grafana_config`
 
-Data type: `String`
+Data type: `Hash`
 
-Name of the influxdb service for the operating system
+Hash of arbitrary configuration settings to pass to Grafana.
+These are added to `grafana.ini` with top-level keys becoming sections and their key-value children becoming settings.
+
+##### `master_list`
+
+Data type: `Puppet_metrics_dashboard::HostList`
+
+An Array of servers that Telegraf will collect Puppet Server metrics from.
+Entries may be:
+  - A String that contains a hostname or IP address.
+    (The module will use a default port number of `8140`)
+  - An Array where the first entry is a String that contains a hostname or IP address,
+    and the second entry is an Integer that specifies the port number.
+Defaults to the result of a PuppetDB query, or `[$trusted['certname']]`
+
+Default value: puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('master')
+
+##### `puppetdb_list`
+
+Data type: `Puppet_metrics_dashboard::HostList`
+
+An Array of servers that Telegraf will collect PuppetDB metrics from.
+Entries may be:
+  - A String that contains a hostname or IP address.
+    (The module will use a default port number of `8081`)
+  - An Array where the first entry is a String that contains a hostname or IP address,
+    and the second entry is an Integer that specifies the port number.
+Defaults to the result of a PuppetDB query, or `[$trusted['certname']]`
+
+Default value: puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('puppetdb')
+
+##### `postgres_host_list`
+
+Data type: `Puppet_metrics_dashboard::HostList`
+
+An Array of servers that Telegraf will collect PostgreSQL metrics from.
+Entries may be:
+  - A String that contains a hostname or IP address.
+    (The module will use a default port number of `5432`)
+  - An Array where the first entry is a String that contains a hostname or IP address,
+    and the second entry is an Integer that specifies the port number.
+Defaults to the results of a PuppetDB query, or `[$trusted['certname']]`
+
+Default value: puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('database')
+
+##### `puppetdb_metrics`
+
+Data type: `Puppet_metrics_dashboard::Puppetdb_metric`
+
+An Array of Hashes containing name/url pairs for each PuppetDB metric.
+Refer to `functions/puppetdb_metrics.pp` for defaults.
+
+Default value: puppet_metrics_dashboard::puppetdb_metrics()
 
 ### puppet_metrics_dashboard::profile::master::postgres_access
 
-Apply this class to a PE-managed postgres instance to allow access from telegraf
+Apply this class to a PE PostgreSQL node to allow access by Telegraf.
 
 #### Examples
 
-##### Allow access to PE-managed Postgres nodes
+##### Apply this class to PE PostgreSQL nodes
 
 ```puppet
 class { 'puppet_metrics_dashboard::profile::master::postgres_access':
-  telegraf_host => 'grafana-server.example.com',
+  telegraf_host => 'dashboard.example.com',
 }
 ```
 
@@ -361,12 +348,12 @@ The following parameters are available in the `puppet_metrics_dashboard::profile
 
 ##### `telegraf_host`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-The FQDN of the host where telegraf runs.
-Defaults to an empty string.  You can explicitly set this parameter or the class attempts to lookup which host has the puppet_metrics_dashboard class applied in PuppetDB.  If the parameter is not set and the lookup does not return anything we issue a warning.
+The FQDN of the host running Telegraf. Defaults to an empty string.
+You can define this parameter, otherwise this class will query PuppetDB for a dashboard host.
 
-Default value: ''
+Default value: `undef`
 
 ### puppet_metrics_dashboard::profile::postgres
 
@@ -558,6 +545,22 @@ The frequency that telegraf will poll for metrics.  Defaults to '5s'
 Default value: '5s'
 
 ## Functions
+
+### puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile
+
+Type: Puppet Language
+
+The puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile class.
+
+#### `puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile(String $profile)`
+
+Returns: `Array`
+
+##### `profile`
+
+Data type: `String`
+
+
 
 ### puppet_metrics_dashboard::puppetdb_metrics
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,36 +1,36 @@
 ---
-# Default Installation parameters
-puppet_metrics_dashboard::add_dashboard_examples: false
 puppet_metrics_dashboard::manage_repos: true
+
+puppet_metrics_dashboard::add_dashboard_examples: false
 puppet_metrics_dashboard::overwrite_dashboards: true
+
+puppet_metrics_dashboard::enable_chronograf: false
+puppet_metrics_dashboard::enable_kapacitor: false
+puppet_metrics_dashboard::enable_telegraf: true
+puppet_metrics_dashboard::configure_telegraf: true
+puppet_metrics_dashboard::consume_graphite: false
+
+puppet_metrics_dashboard::influxdb_database_name:
+  - "telegraf"
+puppet_metrics_dashboard::influxdb_urls:
+  - "http://localhost:8086"
+
+puppet_metrics_dashboard::influx_db_password: "puppet"
+
+puppet_metrics_dashboard::telegraf_db_name: "telegraf"
+puppet_metrics_dashboard::http_response_timeout: "5s"
+puppet_metrics_dashboard::telegraf_agent_interval: "5s"
+puppet_metrics_dashboard::pg_query_interval: "10m"
+
 puppet_metrics_dashboard::use_dashboard_ssl: false
 puppet_metrics_dashboard::dashboard_cert_file: "/etc/grafana/%{clientcert}_cert.pem"
 puppet_metrics_dashboard::dashboard_cert_key: "/etc/grafana/%{clientcert}_key.pem"
-puppet_metrics_dashboard::influxdb_database_name:
-  - "telegraf"
-puppet_metrics_dashboard::grafana_version: "5.1.4"
+
 puppet_metrics_dashboard::grafana_http_port: 3000
-puppet_metrics_dashboard::influx_db_password: "puppet"
 puppet_metrics_dashboard::grafana_password: "admin"
-puppet_metrics_dashboard::consume_graphite: false
-# Influxdb TICK stack
-puppet_metrics_dashboard::enable_telegraf: true
-puppet_metrics_dashboard::enable_kapacitor: false
-puppet_metrics_dashboard::enable_chronograf: false
-# telegraf config
-puppet_metrics_dashboard::configure_telegraf: true
-puppet_metrics_dashboard::master_list:
-  - "%{trusted.certname}"
-puppet_metrics_dashboard::puppetdb_list:
-  - "%{trusted.certname}"
-puppet_metrics_dashboard::postgres_host_list:
-  - "%{trusted.certname}"
-puppet_metrics_dashboard::influxdb_urls:
-  - "http://localhost:8086"
-puppet_metrics_dashboard::telegraf_db_name: "telegraf"
-puppet_metrics_dashboard::telegraf_agent_interval: "5s"
-puppet_metrics_dashboard::http_response_timeout: "5s" # this is the default value for the HTTP JSON Input
-puppet_metrics_dashboard::pg_query_interval: "10m"
+puppet_metrics_dashboard::grafana_version: "5.1.4"
 
 puppet_metrics_dashboard::overwrite_dashboards_file: "/opt/puppetlabs/puppet/cache/state/overwrite_dashboards_disabled"
+
 puppet_metrics_dashboard::grafana_config: {}
+

--- a/functions/localhost_or_hosts_with_pe_profile.pp
+++ b/functions/localhost_or_hosts_with_pe_profile.pp
@@ -1,0 +1,35 @@
+# Function: localhost_or_hosts_with_pe_profile
+#
+# Queries PuppetDB for hosts with the specified Puppet Enterprise profile.
+# Used by this module to query Puppet Enterprise API endpoints.
+
+# Parameters:
+#
+# $profile: the short name of the Puppet Enterprise profile.
+
+# Results:
+#
+# $hosts: an array of certnames.
+#
+# Returns [$trusted['certname']] when PuppetDB returns no hosts.
+
+function puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile($profile) {
+  if $settings::storeconfigs {
+    $_profile = capitalize($profile)
+    $hosts = puppetdb_query("resources[certname] {
+               type = 'Class' and
+               title = 'Puppet_enterprise::Profile::${_profile}' and
+               nodes { deactivated is null and expired is null }
+              }").map |$nodes| { $nodes['certname'] }
+  }
+  else {
+    $hosts = []
+  }
+
+  if empty($hosts) {
+    [$trusted['certname']]
+  }
+  else {
+    sort($hosts)
+  }
+}

--- a/functions/localhost_or_hosts_with_pe_profile.pp
+++ b/functions/localhost_or_hosts_with_pe_profile.pp
@@ -1,28 +1,25 @@
-# Function: localhost_or_hosts_with_pe_profile
+# @summary function used to determine hosts with a Puppet Enterprise profile
 #
 # Queries PuppetDB for hosts with the specified Puppet Enterprise profile.
-# Used by this module to query Puppet Enterprise API endpoints.
-
-# Parameters:
+# Used by this module to identify hosts with Puppet Enterprise API endpoints.
 #
-# $profile: the short name of the Puppet Enterprise profile.
-
-# Results:
+# @param profile [String]
+#   The short name of the Puppet Enterprise profile to query.
 #
-# $hosts: an array of certnames.
-#
-# Returns [$trusted['certname']] when PuppetDB returns no hosts.
+# @return [Array[String]]
+#   An array of certnames from the query, or the local certname when the query returns no hosts.
 
-function puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile($profile) {
+function puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile(
+  String $profile,
+) >> Array {
   if $settings::storeconfigs {
     $_profile = capitalize($profile)
     $hosts = puppetdb_query("resources[certname] {
-               type = 'Class' and
-               title = 'Puppet_enterprise::Profile::${_profile}' and
-               nodes { deactivated is null and expired is null }
-              }").map |$nodes| { $nodes['certname'] }
-  }
-  else {
+      type = 'Class' and
+      title = 'Puppet_enterprise::Profile::${_profile}' and
+      nodes { deactivated is null and expired is null }
+    }").map |$nodes| { $nodes['certname'] }
+  } else {
     $hosts = []
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,154 +1,117 @@
-# @summary Installs and configures Grafana with InfluxDB for monitoring Puppet infrastructure.
+# @summary Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics.
 #
-# The puppet_metrics_dashboard module installs and configures an InfluxDB stack
-# monitor the Puppet infrastructure components.
+# Refer to `data/common.yaml` for defaults.
+#
+# @param manage_repos
+#   Whether to configure apt / yum repositories for required packages.
+#   Valid values are `true`, `false`. Defaults to `true`
 #
 # @param add_dashboard_examples
-#   Whether to add the Grafana dashboard example dashboards for the configured InfluxDB databases.
+#   Whether to add the example Grafana dashboards for the configured InfluxDB databases.
 #   Valid values are `true`, `false`. Defaults to `false`.
 #   _Note_: These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
 #
-# @param manage_repos
-#   Whether or not to setup yum / apt repositories for the dependent packages
+# @param overwrite_dashboards
+#   Whether to overwrite the example Grafana dashboards.
 #   Valid values are `true`, `false`. Defaults to `true`
-#
-# @param dashboard_cert_file
-#   The location of the Grafana certficiate.
-#   Defaults to `"/etc/grafana/${clientcert}_cert.pem"`
-#   Only used when configuring `use_dashboard_ssl` is true.
-#
-# @param dashboard_cert_key
-#   The location of the Grafana private key.
-#   Defaults to `"/etc/grafana/${clientcert}_key.pem"`
-#   Only used when configuring `use_dashboard_ssl` is true.
-#
-# @param configure_telegraf
-#   Whether to configure the telegraf service.
-#   Valid values are `true`, `false`. Defaults to `true`
-#   This parameter enables configuring telegraf to query the `master_list` and `puppetdb_list` endpoints for metrics. Metrics will be stored
-#   in the `telegraf` database in InfluxDb. Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
-#   _Note:_ This parameter is only used if `enable_telegraf` is set to true.
-#
-# @param consume_graphite
-#   Whether to enable the InfluxDB Graphite plugin.
-#   Valid values are `true`, `false`. Defaults to `false`
-#   This parameter enables the Graphite plugin for InfluxDB to allow for injesting Graphite metrics. Ensure `influxdb_database_name`
-#   contains `graphite` when using this parameter.
-#   _Note:_ If using Graphite metrics from the Puppet Master, this needs to be set to `true`.
-#
-# @param grafana_http_port
-#   The port to run Grafana on.
-#   Valid values are Integers from `1024` to `65536`. Defaults to `3000`
-#   The grafana port for the web interface. This should be a nonprivileged port (above 1024).
-#
-# @param grafana_password
-#   The password for the Grafana admin user.
-#   Defaults to `'admin'`
-#
-# @param grafana_version
-#   The grafana version to install.
-#   Valid values are String versions of Grafana. Defaults to `'4.5.2'`
-#
-# @param influxdb_database_name
-#   An array of databases that should be created in InfluxDB.
-#   Valid values are 'puppet_metrics','telegraf', 'graphite', and any other string. Defaults to `['puppet_metrics']`
-#   Each database in the array will be created in InfluxDB. 'puppet_metrics','telegraf', and 'graphite' are specially named and will
-#   be used with their associated metric collection method. Any other database name will be created, but not utilized with
-#   components in this module.
-#
-# @param influx_db_password
-#   The password for the InfluxDB admin user.
-#   Defaults to `'puppet'`
-#
-# @param enable_kapacitor
-#   Whether to install kapacitor.
-#   Valid values are `true`, `false`. Defaults to `false`
-#   Install kapacitor. No configuration of kapacitor is included at this time.
+#   This parameter disables overwriting the example Grafana dashboards.
+#   It takes effect after the second Puppet run, and populates a `overwrite_dashboards_disabled` fact. 
+#   Only used when `add_dashboard_examples` is `true`.
 #
 # @param enable_chronograf
 #   Whether to install chronograf.
 #   Valid values are `true`, `false`. Defaults to `false`
-#   Installs chronograf. No configuration of chronograf is included at this time.
+#   No configuration of chronograf is included at this time.
+#
+# @param enable_kapacitor
+#   Whether to install kapacitor.
+#   Valid values are `true`, `false`. Defaults to `false`
+#   No configuration of kapacitor is included at this time.
 #
 # @param enable_telegraf
 #   Whether to install telegraf.
+#   Valid values are `true`, `false`. Defaults to `true`
+#   No configuration is done unless `configure_telegraf` is set to `true`.
+#
+# @param configure_telegraf
+#   Whether to configure the Telegraf service.
+#   Valid values are `true`, `false`. Defaults to `true`
+#   This parameter enables and configures Telegraf to query the `*_list` hosts for metrics.
+#   Metrics will be stored in the `telegraf` database in InfluxDb.
+#   Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
+#   Only used when `enable_telegraf` is `true`.
+#
+# @param consume_graphite
+#   Whether to enable the InfluxDB Graphite plugin.
 #   Valid values are `true`, `false`. Defaults to `false`
-#   Installs telegraf. No configuration is done unless the `configure_telegraf` parameter is set to `true`.
+#   This parameter enables the Graphite plugin for InfluxDB to allow for consuming Graphite metrics.
+#   Ensure `influxdb_database_name` contains `graphite` when using this parameter.
+#   _Note:_ To consume metrics sent from Puppet Server, this must to be set to `true`.
 #
-# @param master_list
-#   A list of Puppet Master servers that Telegraf will be configured to
-#   collect metrics from. Entries in the list may be:
-#     - A single string that contains a hostname or IP address.
-#       The module will use a default port number of 8140.
-#     - A list of length two, where the first entry is a string that
-#       contains a hostname or IP address and the second entry is an
-#       integer that specifies the port number.
-#   Defaults to `[$trusted['certname']]`
-#
-# @param puppetdb_metrics
-#   An array of hashes containing name / url pairs for each puppetdb metric.
-#   See functions/puppetdb_metrics.pp for defaults.
+# @param influxdb_database_name
+#   An Array of databases that should be created in InfluxDB.
+#   Valid values are `telegraf`, `graphite`, `puppet_metrics`, and any other string. Defaults to `["telegraf"]`
+#   Each database in the array will be created in InfluxDB. 
+#   `telegraf`, `graphite`, and `puppet_metrics` are specially named and will be used with their associated metric collection method.
+#   Any other database name will be created, but not associated with components in this module.
 #
 # @param influxdb_urls
-#   An array for telegraf's config defining where influxdb instances are
-#
-# @param telegraf_db_name
-#   The database in influxdb where telefraf metrics are stored
-#
-# @param telegraf_agent_interval
-#   How often the telefraf agent queries for metrics.  Defaults to "5s"
-#
-# @param http_response_timeout
-#   How long to wait for the queries by telegraf to finish before giving up. Defaults to "5s"
-#
-# @param pg_query_interval
-#   How often postgres queries will run when monitoring a postgres host. Defaults to "10m"
-#
-# @param overwrite_dashboards
-#   Whether to overwrite the example Grafana dashboards.
-#   Valid values are `true`, `false`. Defaults to `false`
-#   This paramater disables overwriting the example Grafana dashboards. It takes effect after the second Puppet run and popultes the
-#   `overwrite_dashboards_disabled` fact. This only takes effect when `add_dashboard_examples` is set to true.
-#
-# @param puppetdb_list
-#   A list of PuppetDB servers that Telegraf will be configured to
-#   collect metrics from. Entries in the list may be:
-#     - A single string that contains a hostname or IP address.
-#       The module will use a default port number of 8081.
-#     - A list of length two, where the first entry is a string that
-#       contains a hostname or IP address and the second entry is an
-#       integer that specifies the port number.
-#   Defaults to `[$trusted['certname']]`
-#
-# @param postgres_host_list
-#   A list of PostgreSQL servers that Telegraf will be configured to
-#   collect metrics from. Entries in the list may be:
-#     - A single string that contains a hostname or IP address.
-#       The module will use a default port number of 5432.
-#     - A list of length two, where the first entry is a string that
-#       contains a hostname or IP address and the second entry is an
-#       integer that specifies the port number.
-#   Defaults to `[$trusted['certname']]`
-#
-# @param use_dashboard_ssl
-#   Whether to enable SSL on Grafana.
-#   Valid values are `true`, `false`. Defaults to `false`
-#
-# @param overwrite_dashboards_file
-#   File in use to populate the overwrite_dashboards fact
+#   An Array containing urls defining InfluxDB instances for Telegraf.
 #
 # @param influx_db_service_name
-#   Name of the influxdb service for the operating system
+#   Name of the InfluxDB service used by the operating system.
+#
+# @param influx_db_password
+#   The password for the InfluxDB `admin` user.
+#   Defaults to `puppet`
+#
+# @param telegraf_db_name
+#   The InfluxDB database where Telegraf metrics are stored.
+#
+# @param http_response_timeout
+#   Timeout for Telegraf HTTP requests. Defaults to `5s`
+#
+# @param telegraf_agent_interval
+#   Frequency of Telegraf HTTP queries for metrics. Defaults to `5s`
+#
+# @param pg_query_interval
+#   Frequency of Telegraf PostgreSQL queries for metrics. Defaults to `10m`
+#
+# @param use_dashboard_ssl
+#   Whether to enable SSL in Grafana.
+#   Valid values are `true`, `false`. Defaults to `false`
+#
+# @param dashboard_cert_file
+#   The location of the Grafana certficiate.
+#   Defaults to `/etc/grafana/${clientcert}_cert.pem`
+#   Only used when `use_dashboard_ssl` is `true`.
+#
+# @param dashboard_cert_key
+#   The location of the Grafana private key.
+#   Defaults to `/etc/grafana/${clientcert}_key.pem`
+#   Only used when `use_dashboard_ssl` is `true`.
+#
+# @param grafana_http_port
+#   The port for the Grafana web interface.
+#   Valid values are Integers from `1024` to `65536`. Defaults to `3000`
+#   This should be a nonprivileged port (above 1024).
+#
+# @param grafana_password
+#   The password for the Grafana `admin` user.
+#   Defaults to `admin`
+#
+# @param grafana_version
+#   The version of Grafana to install.
+#   Valid values are String versions of Grafana.
+#
+# @param overwrite_dashboards_file
+#   File used to populate the `overwrite_dashboards` fact.
 #
 # @param grafana_config
-#   Hash of arbitrary config to pass to grafana, this is placed in the
-#   grafana.ini file with top-level keys becoming sections and their
-#   key-value children becoming settings.
+#   Hash of arbitrary configuration settings to pass to Grafana.
+#   These are added to `grafana.ini` with top-level keys becoming sections and their key-value children becoming settings.
 #
-# @example Default Configuration
-#   include puppet_metrics_dashboard
-#
-# @example Default Configuration with no login
+# @example Grafana with no login
 #   class { 'puppet_metrics_dashboard':
 #     grafana_config => {
 #       'users'          => {
@@ -160,86 +123,81 @@
 #     },
 #   }
 #
-# @example Configure Telegraf on a list of masters and PuppetDB servers
-#   class { 'puppet_metrics_dashboard':
-#     configure_telegraf  => true,
-#     enable_telegraf     => true,
-#     master_list         => ['master1.com',
-#                             # Alternate ports may be configured using
-#                             # a list of: `[hostname, port_number]`
-#                             ['master2.com', 9140]],
-#     puppetdb_list       => ['puppetdb1',
-#                             ['puppetdb2', 8100]],
-#   }
+# @param master_list
+#   An Array of servers that Telegraf will collect Puppet Server metrics from. 
+#   Entries may be:
+#     - A String that contains a hostname or IP address.
+#       (The module will use a default port number of `8140`)
+#     - An Array where the first entry is a String that contains a hostname or IP address,
+#       and the second entry is an Integer that specifies the port number.
+#   Defaults to the result of a PuppetDB query, or `[$trusted['certname']]`
 #
-# @example Install example dashboards for all of the collection methods
-#   class { 'puppet_metrics_dashboard':
-#     add_dashboard_examples => true,
-#     influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
-#   }
+# @param puppetdb_list
+#   An Array of servers that Telegraf will collect PuppetDB metrics from. 
+#   Entries may be:
+#     - A String that contains a hostname or IP address.
+#       (The module will use a default port number of `8081`)
+#     - An Array where the first entry is a String that contains a hostname or IP address,
+#       and the second entry is an Integer that specifies the port number.
+#   Defaults to the result of a PuppetDB query, or `[$trusted['certname']]`
 #
-# @example Configure telegraf for one or more masters / puppetdb nodes
-#   class { 'puppet_metrics_dashboard':
-#     configure_telegraf  => true,
-#     enable_telegraf     => true,
-#     master_list         => ['master1.com','master2.com'],
-#     puppetdb_list       => ['puppetdb1','puppetdb2'],
-#   }
+# @param postgres_host_list
+#   An Array of servers that Telegraf will collect PostgreSQL metrics from. 
+#   Entries may be:
+#     - A String that contains a hostname or IP address.
+#       (The module will use a default port number of `5432`)
+#     - An Array where the first entry is a String that contains a hostname or IP address,
+#       and the second entry is an Integer that specifies the port number.
+#   Defaults to the results of a PuppetDB query, or `[$trusted['certname']]`
 #
-# @example Enable Graphite support
-#   class { 'puppet_metrics_dashboard':
-#     add_dashboard_examples => true,
-#     consume_graphite       => true,
-#     influxdb_database_name => ["graphite"],
-#     master_list            => ["master01.example.com","master02.org"],
-#   }
-#
-# @example Enable Telegraf, Graphite, and Archive
-#  class { 'puppet_metrics_dashboard':
-#    add_dashboard_examples => true,
-#    influxdb_database_name => ['puppet_metrics','telegraf','graphite'],
-#    consume_graphite       => true,
-#    configure_telegraf     => true,
-#    enable_telegraf        => true,
-#  }
-#
-# @example Enable SSL
-#   class { 'puppet_metrics_dashboard':
-#     use_dashboard_ssl => true,
-#   }
+# @param puppetdb_metrics
+#   An Array of Hashes containing name/url pairs for each PuppetDB metric.
+#   Refer to `functions/puppetdb_metrics.pp` for defaults.
 #
 class puppet_metrics_dashboard (
-  Boolean $add_dashboard_examples,
   Boolean $manage_repos,
-  Boolean $use_dashboard_ssl,
-  String $dashboard_cert_file,
-  String $dashboard_cert_key,
+
+  Boolean $add_dashboard_examples,
   Boolean $overwrite_dashboards,
-  String $overwrite_dashboards_file,
-  String $influx_db_service_name,
-  Array[String] $influxdb_database_name,
-  String $grafana_version,
-  Integer $grafana_http_port,
-  String $influx_db_password,
-  String $grafana_password,
-  Boolean $enable_kapacitor,
+
   Boolean $enable_chronograf,
+  Boolean $enable_kapacitor,
   Boolean $enable_telegraf,
   Boolean $configure_telegraf,
   Boolean $consume_graphite,
-  Puppet_metrics_dashboard::HostList $master_list,
-  Puppet_metrics_dashboard::HostList $puppetdb_list,
-  Puppet_metrics_dashboard::HostList $postgres_host_list,
+
+  Array[String] $influxdb_database_name,
   Array[String] $influxdb_urls,
+
+  String $influx_db_service_name,
+  String $influx_db_password,
+
   String $telegraf_db_name,
   String[2] $telegraf_agent_interval,
   String[2] $http_response_timeout,
   String[2] $pg_query_interval,
+
+  Boolean $use_dashboard_ssl,
+  String $dashboard_cert_file,
+  String $dashboard_cert_key,
+
+  Integer $grafana_http_port,
+  String $grafana_password,
+  String $grafana_version,
+
+  String $overwrite_dashboards_file,
+
   Hash $grafana_config,
+
+  Puppet_metrics_dashboard::HostList $master_list        = puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('master'),
+  Puppet_metrics_dashboard::HostList $puppetdb_list      = puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('puppetdb'),
+  Puppet_metrics_dashboard::HostList $postgres_host_list = puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile('database'),
+
   Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = puppet_metrics_dashboard::puppetdb_metrics(),
   ) {
+
   unless $facts['os']['family'] =~ /^(RedHat|Debian)$/ {
-    fail("${facts['os']['family']} installation not supported")
+    fail("Installation on ${facts['os']['family']} is not supported")
   }
 
   if $manage_repos {
@@ -266,7 +224,7 @@ class puppet_metrics_dashboard (
     contain puppet_metrics_dashboard::dashboards
   }
 
-  # Enable Telegraf if `configure_telegraf` is true.
+  # Always enable Telegraf if `configure_telegraf` is `true`.
   $_enable_telegraf = $configure_telegraf ? {
     true    => true,
     default => $enable_telegraf

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,49 +1,42 @@
-# @summary Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics.
+# @summary Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics
 #
-# Refer to `data/common.yaml` for defaults.
+# Installs and configures a stack for collecting, storing, and displaying Puppet Infrastructure metrics.
+# Refer to `data/common.yaml` for additional parameter defaults.
 #
-# @param manage_repos
+# @param [Boolean] manage_repos
 #   Whether to configure apt / yum repositories for required packages.
-#   Valid values are `true`, `false`. Defaults to `true`
 #
-# @param add_dashboard_examples
-#   Whether to add the example Grafana dashboards for the configured InfluxDB databases.
-#   Valid values are `true`, `false`. Defaults to `false`.
+# @param [Boolean] add_dashboard_examples
+#   Whether to add the example Grafana dashboards for the configured InfluxDB databases. Defaults to `false`.
 #   _Note_: These dashboards are managed and any changes will be overwritten unless the `overwrite_dashboards` is set to `false`.
 #
-# @param overwrite_dashboards
-#   Whether to overwrite the example Grafana dashboards.
-#   Valid values are `true`, `false`. Defaults to `true`
+# @param [Boolean] overwrite_dashboards
+#   Whether to overwrite the example Grafana dashboards. Defaults to `true`
 #   This parameter disables overwriting the example Grafana dashboards.
 #   It takes effect after the second Puppet run, and populates a `overwrite_dashboards_disabled` fact. 
 #   Only used when `add_dashboard_examples` is `true`.
 #
-# @param enable_chronograf
-#   Whether to install chronograf.
-#   Valid values are `true`, `false`. Defaults to `false`
+# @param [Boolean] enable_chronograf
+#   Whether to install chronograf. Defaults to `false`
 #   No configuration of chronograf is included at this time.
 #
-# @param enable_kapacitor
-#   Whether to install kapacitor.
-#   Valid values are `true`, `false`. Defaults to `false`
+# @param [Boolean] enable_kapacitor
+#   Whether to install kapacitor. Defaults to `false`
 #   No configuration of kapacitor is included at this time.
 #
-# @param enable_telegraf
-#   Whether to install telegraf.
-#   Valid values are `true`, `false`. Defaults to `true`
+# @param [Boolean] enable_telegraf
+#   Whether to install telegraf. Defaults to `true`
 #   No configuration is done unless `configure_telegraf` is set to `true`.
 #
-# @param configure_telegraf
-#   Whether to configure the Telegraf service.
-#   Valid values are `true`, `false`. Defaults to `true`
+# @param [Boolean] configure_telegraf
+#   Whether to configure the Telegraf service. Defaults to `true`
 #   This parameter enables and configures Telegraf to query the `*_list` hosts for metrics.
 #   Metrics will be stored in the `telegraf` database in InfluxDb.
 #   Ensure that `influxdb_database_name` contains `telegraf` when using this parameter.
 #   Only used when `enable_telegraf` is `true`.
 #
-# @param consume_graphite
-#   Whether to enable the InfluxDB Graphite plugin.
-#   Valid values are `true`, `false`. Defaults to `false`
+# @param [Boolean] consume_graphite
+#   Whether to enable the InfluxDB Graphite plugin. Defaults to `false`
 #   This parameter enables the Graphite plugin for InfluxDB to allow for consuming Graphite metrics.
 #   Ensure `influxdb_database_name` contains `graphite` when using this parameter.
 #   _Note:_ To consume metrics sent from Puppet Server, this must to be set to `true`.
@@ -153,6 +146,36 @@
 # @param puppetdb_metrics
 #   An Array of Hashes containing name/url pairs for each PuppetDB metric.
 #   Refer to `functions/puppetdb_metrics.pp` for defaults.
+#
+# @example Configure Telegraf to collect metrics from a list of Masters, PuppetDB, and PostgreSQL servers
+#   class { 'puppet_metrics_dashboard':
+#     add_dashboard_examples => true,
+#     overwrite_dashboards   => false,
+#     configure_telegraf     => true,
+#     enable_telegraf        => true,
+#     master_list            => ['master.example.com', ['compiler01.example.com', 9140], ['compiler02.example.com', 9140]],
+#     puppetdb_list          => ['puppetdb01.example.com', 'puppetdb02.example.com'],
+#     postgres_host_list     => ['postgres01.example.com', 'postgres02.example.com'],
+#   }
+#
+# @example Configure Graphite to accept metrics from a list of Masters
+#   class { 'puppet_metrics_dashboard':
+#     add_dashboard_examples => true,
+#     overwrite_dashboards   => false,
+#     consume_graphite       => true,
+#     influxdb_database_name => ['graphite'],
+#     master_list            => ['master', 'master02'],
+#   }
+#
+# @example Configure Telegraf, Graphite, and Archive
+#  class { 'puppet_metrics_dashboard':
+#    add_dashboard_examples => true,
+#    overwrite_dashboards   => false,
+#    consume_graphite       => true,
+#    configure_telegraf     => true,
+#    enable_telegraf        => true,
+#    influxdb_database_name => ['telegraf', 'graphite', 'puppet_metrics'],
+#  }
 #
 class puppet_metrics_dashboard (
   Boolean $manage_repos,

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -1,0 +1,17 @@
+# @summary Install requirements for the voxpupuli/puppet-telegraf module.
+#
+# @example Apply this class to the Master and any/all Compilers.
+#   include puppet_metrics_dashboard::profile::master::install
+#
+class puppet_metrics_dashboard::profile::master::install {
+  $puppetserver_service = $facts['pe_server_version'] ? {
+    /./     => 'pe-puppetserver',
+    default => 'puppetserver',
+  }
+
+  package { 'toml-rb':
+    ensure   => present,
+    provider => 'puppetserver_gem',
+    notify   => Service[$puppetserver_service],
+  }
+}

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -1,12 +1,15 @@
-# @summary Install requirements for the voxpupuli/puppet-telegraf module.
+# @summary Install requirements for the voxpupuli/puppet-telegraf module
 #
-# @example Apply this class to the Master and any/all Compilers.
+# Install requirements for the voxpupuli/puppet-telegraf module.
+#
+# @example Apply this class to the Master and any/all Compilers
 #   include puppet_metrics_dashboard::profile::master::install
 #
 class puppet_metrics_dashboard::profile::master::install {
-  $puppetserver_service = $facts['pe_server_version'] ? {
-    /./     => 'pe-puppetserver',
-    default => 'puppetserver',
+  if $facts['pe_server_version'] {
+    $puppetserver_service = 'pe-puppetserver'
+  } else {
+    $puppetserver_service = 'puppetserver'
   }
 
   package { 'toml-rb':

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -1,19 +1,19 @@
-# @summary Apply this class to a PE-managed postgres instance to allow access from telegraf
+# @summary Apply this class to a PE PostgreSQL node to allow access by Telegraf.
 #
 # @param telegraf_host
-#   The FQDN of the host where telegraf runs.  
-#   Defaults to an empty string.  You can explicitly set this parameter or the class attempts to lookup which host has the puppet_metrics_dashboard class applied in PuppetDB.  If the parameter is not set and the lookup does not return anything we issue a warning.
+#   The FQDN of the host running Telegraf. Defaults to an empty string.
+#   You can define this parameter, otherwise this class will query PuppetDB for a dashboard host.
 #
-# @example Allow access to PE-managed Postgres nodes
+# @example Apply this class to PE PostgreSQL nodes.
 #   class { 'puppet_metrics_dashboard::profile::master::postgres_access':
-#     telegraf_host => 'grafana-server.example.com',
+#     telegraf_host => 'dashboard.example.com',
 #   }
 #
 class puppet_metrics_dashboard::profile::master::postgres_access (
-  String $telegraf_host = ''
+  String $telegraf_host = "" # lint:ignore:double_quoted_strings
 ){
 
-  ##If a value is not supplied, we try a lookup
+  # If $telegraf_host is not defined, query PuppetDB for a dashboard host.
 
   if $telegraf_host.empty {
     $_query = puppetdb_query('resources[certname] {
@@ -31,11 +31,11 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
     $_telegraf_host = $telegraf_host
   }
 
-  ##If no value is supplied _and_ the lookup returns nothing, we issue a warning and do nothing
+  # If $telegraf_host is not defined and the query fails to find a dashboard host, issue a warning.
 
   if $_telegraf_host == undef {
 
-    notify{ 'This class configures access for a telegaf client to connect to pe-postgresql, you must apply the Puppet_metrics_dashboard class must to an agent or set $telegraf_host before this can happen.  $telegraf_host is undef':}
+    notify { 'You must specify telegraf_host (or apply the puppet_metrics_dashboard class to an agent) to enable access.': }
 
   } else {
 
@@ -47,7 +47,7 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
       role      => 'telegraf',
     }
 
-    ##If this fact doesn't exist then postgres is probably at v9.4
+    # If the fact doesn't exist then PostgreSQL is probably version 9.4.
 
     if $facts['pe_postgresql_info']['installed_server_version'] {
       $postgres_version = $facts['pe_postgresql_info']['installed_server_version']

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -4,18 +4,20 @@
 #   The FQDN of the host running Telegraf. Defaults to an empty string.
 #   You can define this parameter, otherwise this class will query PuppetDB for a dashboard host.
 #
-# @example Apply this class to PE PostgreSQL nodes.
+# @example Apply this class to PE PostgreSQL nodes
 #   class { 'puppet_metrics_dashboard::profile::master::postgres_access':
 #     telegraf_host => 'dashboard.example.com',
 #   }
 #
 class puppet_metrics_dashboard::profile::master::postgres_access (
-  String $telegraf_host = "" # lint:ignore:double_quoted_strings
+  Optional[String[1]] $telegraf_host = undef
 ){
 
-  # If $telegraf_host is not defined, query PuppetDB for a dashboard host.
+  # Unless $telegraf_host is defined, query PuppetDB for a dashboard host.
 
-  if $telegraf_host.empty {
+  if $telegraf_host {
+    $_telegraf_host = $telegraf_host
+  } else {
     $_query = puppetdb_query('resources[certname] {
       type = "Class" and
       title = "Puppet_metrics_dashboard" and
@@ -26,9 +28,9 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
       order by certname asc
       limit 1
     }')
-    unless $_query.empty {$_telegraf_host = $_query[0]['certname']}
-  } else {
-    $_telegraf_host = $telegraf_host
+    unless $_query.empty {
+      $_telegraf_host = $_query[0]['certname']
+    }
   }
 
   # If $telegraf_host is not defined and the query fails to find a dashboard host, issue a warning.


### PR DESCRIPTION
With this commit ...

Simplify and sort information in README.md.
Document issue with hostnames versus domain names (dots) and Graphite.
Correct toml-rb gem requirements: only needed in Puppet Server.
Require puppetserver_gem module to install toml-rb gem.
Add profile::master::install class to install toml-rb gem.
Clarify issue with profile::master::postgres_access and pe-postgres resources.
Automate *_list parameters.
Group similar parameters in init.pp and common.yaml.
Document that class parameter defaults are defined in common.yaml.