### PR TITLE
(INFC-19230) Updated to pdk 1.15.0, fix metadata.json

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
+  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -88,6 +89,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,11 @@
   "issues_url": "https://github.com/puppetlabs/puppet_metrics_dashboard/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "name": "puppet-grafana",
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     },
     {
-      "name": "puppetlabs-inifile",
+      "name": "puppet-telegraf",
       "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
@@ -21,12 +21,16 @@
       "version_requirement": ">= 4.3.0 < 8.0.0"
     },
     {
-      "name": "puppet-grafana",
-      "version_requirement": ">= 3.0.0 < 7.0.0"
+      "name": "puppetlabs-inifile",
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
-      "name": "puppet-telegraf",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "name": "puppetlabs-puppetserver_gem",
+      "version_requirement": ">= 1.1.1 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.13.0",
-  "template-url": "pdk-default#1.13.0",
-  "template-ref": "1.13.0-0-g66e1443"
+  "pdk-version": "1.15.0",
+  "template-url": "pdk-default#1.15.0",
+  "template-ref": "tags/1.15.0-0-g0bc522e"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,5 +3,6 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
Fixes #82 by updating to a newer version of the PDK and resolving issues with metadata.json that kept acceptance tests from passing.

This PR sorts the dependencies in metadata.json and makes the following actual changes:

- telegraf's upper limit is raised to < 4.0.0
- inifile's upper limit is raised to < 5.0.0
- puppetserver_gem is added

The diff post-sorting is

```diff
--- 	2020-01-02 18:36:47 +0000
+++ 	2020-01-02 18:36:47 +0000
@@ -5,7 +5,7 @@
     },
     {
       "name": "puppet-telegraf",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs-apt",
@@ -13,10 +13,14 @@
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs-puppetserver_gem",
+      "version_requirement": ">= 1.1.1 < 3.0.0"
     },
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 1.0.0 < 7.0.0"
     }
-]
+  ]
```