### PR TITLE
Remove deprecated pe- metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## 2020-1-13 - Release - 2.0.2
+
+### Bugfixes
+ - Update the included dashboards to not reference deprecated `pe-` metrics
+
 ## 2019-7-11 - Release - 2.0.1
 
 ### Bugfixes

--- a/files/Archive_File_Sync.json
+++ b/files/Archive_File_Sync.json
@@ -86,7 +86,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-lock-held-time",
+              "measurement": "puppetserver.jruby-metrics.average-lock-held-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -136,7 +136,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-lock-wait-time",
+              "measurement": "puppetserver.jruby-metrics.average-lock-wait-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "B",

--- a/files/Puppetserver_Performance.json
+++ b/files/Puppetserver_Performance.json
@@ -87,10 +87,10 @@
                 }
               ],
               "hide": false,
-              "measurement": "puppetserver.pe-jruby-metrics.average-free-jrubies",
+              "measurement": "puppetserver.jruby-metrics.average-free-jrubies",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "SELECT distinct(\"average-free-jrubies\") FROM \"puppetserver.pe-jruby-metrics.average-free-jrubies\" WHERE $timeFilter GROUP BY time(10s) fill(null)",
+              "query": "SELECT distinct(\"average-free-jrubies\") FROM \"puppetserver.jruby-metrics.average-free-jrubies\" WHERE $timeFilter GROUP BY time(10s) fill(null)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -139,7 +139,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-requested-jrubies",
+              "measurement": "puppetserver.jruby-metrics.average-requested-jrubies",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "B",
@@ -189,7 +189,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-wait-time",
+              "measurement": "puppetserver.jruby-metrics.average-wait-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "C",
@@ -239,7 +239,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-borrow-time",
+              "measurement": "puppetserver.jruby-metrics.average-borrow-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "D",
@@ -617,7 +617,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-requested-jrubies",
+              "measurement": "puppetserver.jruby-metrics.average-requested-jrubies",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -735,7 +735,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-borrow-time",
+              "measurement": "puppetserver.jruby-metrics.average-borrow-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -785,7 +785,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-puppet-profiler.catalog-metrics",
+              "measurement": "puppetserver.puppet-profiler.catalog-metrics",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "B",
@@ -921,7 +921,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-free-jrubies",
+              "measurement": "puppetserver.jruby-metrics.average-free-jrubies",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -1039,7 +1039,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "puppetserver.pe-jruby-metrics.average-wait-time",
+              "measurement": "puppetserver.jruby-metrics.average-wait-time",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",

--- a/files/Telegraf_File_Sync.json
+++ b/files/Telegraf_File_Sync.json
@@ -89,7 +89,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-lock-held-time"
+                      "jruby-metrics_status_experimental_metrics_average-lock-held-time"
                     ],
                     "type": "field"
                   },
@@ -133,7 +133,7 @@
                 [
                   {
                     "params": [
-                      "pe-jruby-metrics_status_experimental_metrics_average-lock-wait-time"
+                      "jruby-metrics_status_experimental_metrics_average-lock-wait-time"
                     ],
                     "type": "field"
                   },

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -30,7 +30,7 @@ describe 'puppet_metrics_dashboard::install class' do
       it 'influxdb accepts data' do
         curlquery = <<-QUERY
           curl -i -X POST 'http://127.0.0.1:8086/write?db=puppet_metrics&precision=s&u=admin&p=puppetlabs' \
-          --data-binary 'puppetserver.pe-jruby-metrics.num-free-jrubies,server=127-0-0-1 num-free-jrubies=1 1523993402'
+          --data-binary 'puppetserver.jruby-metrics.num-free-jrubies,server=127-0-0-1 num-free-jrubies=1 1523993402'
           QUERY
         shell(curlquery.to_s) do |r|
           expect(r.exit_code).to eq(0)
@@ -41,11 +41,11 @@ describe 'puppet_metrics_dashboard::install class' do
       it 'influxdb answers data queries' do
         curlquery = <<-QUERY
           curl -i -X POST 'http://127.0.0.1:8086/query?db=puppet_metrics&u=admin&p=puppetlabs' \
-          --data-urlencode 'q=SELECT * FROM "puppetserver.pe-jruby-metrics.num-free-jrubies"'
+          --data-urlencode 'q=SELECT * FROM "puppetserver.jruby-metrics.num-free-jrubies"'
           QUERY
         shell(curlquery.to_s) do |r|
           expect(r.exit_code).to eq(0)
-          expect(r.stdout).to match(%r{puppetserver.pe-jruby-metrics.num-free-jrubies})
+          expect(r.stdout).to match(%r{puppetserver.jruby-metrics.num-free-jrubies})
         end
       end
 


### PR DESCRIPTION
Version 5.3.0 of the metrics collector removed several of these metrics,
as they were duplicates.  The dashboards in this commit should work with
any version of PE >= 2017.3.x