### PR TITLE
OSP Compatibility Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## 2020-1-31 - Release - 2.1.0
+
+### Bug Fixes
+ - Remove the file sync query from PuppetDB metrics when `pe_server_version` is not defined when using Telegraf
+
+### Changes
+ - Use the client SSL certificate when querying PuppetDB metrics with Telegraf
+ - Allow for specifying the PostgreSQL databases in the PostgreSQL profile
+
 ## 2020-1-13 - Release - 2.0.2
 
 ### Bugfixes

--- a/manifests/profile/compiler.pp
+++ b/manifests/profile/compiler.pp
@@ -37,7 +37,7 @@ define puppet_metrics_dashboard::profile::compiler (
     require     => Package['telegraf'],
   }
 
-if $facts['pe_server_version'] =~ NotUndef {
+if $facts['pe_server_version'] {
     telegraf::input { "pe_last_file_sync_${compiler}":
       plugin_type => 'http',
       options     => [{

--- a/manifests/profile/compiler.pp
+++ b/manifests/profile/compiler.pp
@@ -37,16 +37,18 @@ define puppet_metrics_dashboard::profile::compiler (
     require     => Package['telegraf'],
   }
 
-  telegraf::input { "pe_last_file_sync_${compiler}":
-    plugin_type => 'http',
-    options     => [{
-      'urls'                 => [ "https://${compiler}:${port}/status/v1/services/file-sync-client-service?level=debug" ],
-      'insecure_skip_verify' => true,
-      'data_format'          => 'json',
-      'json_string_fields'   => ['status_repos_puppet-code_latest_commit_date'],
-      'timeout'              => $timeout,
-    }],
-    notify      => Service['telegraf'],
-    require     => Package['telegraf'],
+if $facts['pe_server_version'] =~ NotUndef {
+    telegraf::input { "pe_last_file_sync_${compiler}":
+      plugin_type => 'http',
+      options     => [{
+        'urls'                 => [ "https://${compiler}:${port}/status/v1/services/file-sync-client-service?level=debug" ],
+        'insecure_skip_verify' => true,
+        'data_format'          => 'json',
+        'json_string_fields'   => ['status_repos_puppet-code_latest_commit_date'],
+        'timeout'              => $timeout,
+      }],
+      notify      => Service['telegraf'],
+      require     => Package['telegraf'],
+    }
   }
 }

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -6,7 +6,7 @@
 #   include puppet_metrics_dashboard::profile::master::install
 #
 class puppet_metrics_dashboard::profile::master::install {
-  if $facts['pe_server_version'] =~ NotUndef {
+  if $facts['pe_server_version'] {
     $puppetserver_service = 'pe-puppetserver'
   } else {
     $puppetserver_service = 'puppetserver'

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -6,7 +6,7 @@
 #   include puppet_metrics_dashboard::profile::master::install
 #
 class puppet_metrics_dashboard::profile::master::install {
-  if $facts['pe_server_version'] {
+  if $facts['pe_server_version'] =~ NotUndef {
     $puppetserver_service = 'pe-puppetserver'
   } else {
     $puppetserver_service = 'puppetserver'

--- a/manifests/profile/master/postgres.pp
+++ b/manifests/profile/master/postgres.pp
@@ -9,6 +9,9 @@
 # @param port
 #   The port that the postgres service listens on.  Defaults to 5432
 #
+# @param databases
+#   An Array of databases to query on. Defaults to `['pe-puppetdb','pe-rbac','pe-activity','pe-classifier']`
+#
 # @example Add telegraf to a postgres server
 #   puppet_metrics_dashboard::profile::master::postgres{ $facts['networking']['fqdn']:
 #     query_interval => '10m',
@@ -18,16 +21,14 @@ define puppet_metrics_dashboard::profile::master::postgres (
   Variant[String,Tuple[String, Integer]] $postgres_host = $facts['networking']['fqdn'],
   String[2] $query_interval                             = lookup('puppet_metrics_dashboard::pg_query_interval'),
   Integer[1] $port                                      = 5432,
-  Array[String] $databases                              = ['pe-puppetdb','pe-rbac','pe-activity','pe-classifier'],
+  Array[String[1]] $databases                           = ['pe-puppetdb','pe-rbac','pe-activity','pe-classifier'],
   ){
 
-  if ! defined(Puppet_metrics_dashboard::Certs['telegraf']) {
-    puppet_metrics_dashboard::certs{'telegraf':
+  ensure_resource( 'puppet_metrics_dashboard::certs', 'telegraf', {
       notify  => Service['telegraf'],
       require => Package['telegraf'],
       before  => Service['telegraf'],
-    }
-  }
+  })
 
   telegraf::input { "pe_postgres_${postgres_host}":
     plugin_type => 'postgresql_extensible',

--- a/manifests/profile/master/postgres.pp
+++ b/manifests/profile/master/postgres.pp
@@ -18,6 +18,7 @@ define puppet_metrics_dashboard::profile::master::postgres (
   Variant[String,Tuple[String, Integer]] $postgres_host = $facts['networking']['fqdn'],
   String[2] $query_interval                             = lookup('puppet_metrics_dashboard::pg_query_interval'),
   Integer[1] $port                                      = 5432,
+  Array[String] $databases                              = ['pe-puppetdb','pe-rbac','pe-activity','pe-classifier'],
   ){
 
   if ! defined(Puppet_metrics_dashboard::Certs['telegraf']) {
@@ -34,7 +35,7 @@ define puppet_metrics_dashboard::profile::master::postgres (
       'interval'      => $query_interval,
       'address'       => "postgres://telegraf@${postgres_host}:${port}/pe-puppetdb?sslmode=require&sslkey=/etc/telegraf/${trusted['certname']}_key.pem&sslcert=/etc/telegraf/${trusted['certname']}_cert.pem&sslrootcert=/etc/telegraf/ca.pem",
       'outputaddress' => $facts['networking']['fqdn'],
-      'databases'     => ['pe-puppetdb','pe-rbac','pe-activity','pe-classifier'],
+      'databases'     => $databases,
       'query'         => [{
         'sqlquery'   => 'SELECT * FROM pg_stat_database',
         'version'    => 901,

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -13,6 +13,9 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
   Optional[String[1]] $telegraf_host = undef
 ){
 
+  unless $facts['pe_server_version'] =~ NotUndef {
+    fail('This class is PE only. Please remove this class and configure PostgreSQL access for your specific configuration.')
+  }
   # Unless $telegraf_host is defined, query PuppetDB for a dashboard host.
 
   if $telegraf_host {

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -13,7 +13,7 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
   Optional[String[1]] $telegraf_host = undef
 ){
 
-  unless $facts['pe_server_version'] =~ NotUndef {
+  unless $facts['pe_server_version'] {
     fail('This class is PE only. Please remove this class and configure PostgreSQL access for your specific configuration.')
   }
   # Unless $telegraf_host is defined, query PuppetDB for a dashboard host.

--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -16,6 +16,9 @@
 # @param interval
 #   The frequency that telegraf will poll for metrics.  Defaults to '5s'
 #
+# @param enable_client_cert
+#   A boolean to enable using the client certificate for the PuppetDB queries. Defaults to true
+#
 # @example Add telegraf to a puppetdb node
 #   puppet_metrics_dashboard::profile::puppetdb{ $facts['networking']['fqdn']:
 #     timeout          => '5s',
@@ -28,18 +31,39 @@ define puppet_metrics_dashboard::profile::puppetdb (
   Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = puppet_metrics_dashboard::puppetdb_metrics(),
   Integer[1] $port                                            = 8081,
   String[2] $interval                                         = '5s',
+  Boolean $enable_client_cert                                 = true,
   ){
+
+  if ! defined(Puppet_metrics_dashboard::Certs['telegraf']) {
+    puppet_metrics_dashboard::certs{'telegraf':
+      notify  => Service['telegraf'],
+      require => Package['telegraf'],
+      before  => Service['telegraf'],
+    }
+  }
+  $cert_dir = '/etc/telegraf'
+  $default_options = $enable_client_cert ? {
+    true => {
+      'tls_key'              => "${cert_dir}/${clientcert}_key.pem",
+      'tls_cert'             => "${cert_dir}/${clientcert}_cert.pem",
+      'tls_ca'               => "${cert_dir}/ca.pem",
+      'insecure_skip_verify' => false,
+    },
+    default => {
+      'insecure_skip_verify' => true,
+    }
+  }
 
   $puppetdb_metrics.each |$metric| {
     telegraf::input { "puppetdb_${metric['name']}_${puppetdb_host}":
       plugin_type => 'httpjson',
       options     => [{
-        'name'                 => "puppetdb_${metric['name']}",
-        'method'               => 'GET',
-        'servers'              => [ "https://${puppetdb_host}:${port}/metrics/v1/mbeans/${metric['url']}" ],
-        'insecure_skip_verify' => true,
-        'response_timeout'     => $timeout,
-      }],
+        'name'             => "puppetdb_${metric['name']}",
+        'method'           => 'GET',
+        'servers'          => [ "https://${puppetdb_host}:${port}/metrics/v1/mbeans/${metric['url']}" ],
+        'response_timeout' => $timeout,
+        } + $default_options
+      ],
       notify      => Service['telegraf'],
       require     => Package['telegraf'],
     }
@@ -48,11 +72,11 @@ define puppet_metrics_dashboard::profile::puppetdb (
   telegraf::input { "puppetdb_command_queue_${puppetdb_host}":
     plugin_type => 'httpjson',
     options     => [{
-      'name'                 => 'puppetdb_command_queue',
-      'servers'              => [ "https://${puppetdb_host}:${port}/status/v1/services?level=debug" ],
-      'insecure_skip_verify' => true,
-      'response_timeout'     => $timeout,
-    }],
+      'name'             => 'puppetdb_command_queue',
+      'servers'          => [ "https://${puppetdb_host}:${port}/status/v1/services?level=debug" ],
+      'response_timeout' => $timeout,
+      } + $default_options
+    ],
     notify      => Service['telegraf'],
     require     => Package['telegraf'],
   }

--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -34,13 +34,12 @@ define puppet_metrics_dashboard::profile::puppetdb (
   Boolean $enable_client_cert                                 = true,
   ){
 
-  if ! defined(Puppet_metrics_dashboard::Certs['telegraf']) {
-    puppet_metrics_dashboard::certs{'telegraf':
+  ensure_resource( 'puppet_metrics_dashboard::certs', 'telegraf', {
       notify  => Service['telegraf'],
       require => Package['telegraf'],
       before  => Service['telegraf'],
-    }
-  }
+  })
+
   $cert_dir = '/etc/telegraf'
   $default_options = $enable_client_cert ? {
     true => {


### PR DESCRIPTION
This PR has some basic OSP compatibility updates to the module. It includes the following. 

* Use the client certificate for all PuppetDB API requests
* ~~Update the `pe_server_version` conditionals to check if `NotUndef`~~
* Remove the file sync query from PuppetDB when `pe_server_version` is not defined
* Allow for specifying the PostgreSQL databases in the profile
* Failing on the `postgres_access` class if it is OSP since it uses PE classes and we cannot guarantee the method used in OSP.

The biggest change is the client certificates on the PuppetDB API requests over skipping validation.

This is a draft PR since there are no spec tests on these profiles and want to identify what is appropriate.