### PR TITLE
(DIO-563) addresses CVE-2020-7943

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Change log
 
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
+
+## TBD - Release - 2.3.0
+
+### Changes
+ - Account for [CVE-2020-7943](https://nvd.nist.gov/vuln/detail/CVE-2020-7943) by configuring telegraf to collect PuppetDB metrics from localhost only on the v2 metrics endpoint, updates dashboards to accomodate new values.
+
+### Bugfixes
 
 ## 2020-3-20 - Release - 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # puppet_metrics_dashboard
 
-- [Description](#Description)
-- [Setup](#Setup)
-  - [Upgrade notes](#Upgrade-notes)
-  - [Determining where Telegraf runs](#Determining-where-Telegraf-runs)
-  - [Requirements](#Requirements)
-- [Usage](#Usage)
-  - [Configure a Monolithic Master and a Dashboard node](#Configure-a-Monolithic-Master-and-a-Dashboard-node)
-  - [Manual configuration of a complex Puppet Infrastructure](#Manual-configuration-of-a-complex-Puppet-Infrastructure)
-  - [Configure Graphite](#Configure-Graphite)
-  - [Configure Telegraf, Graphite, and Archive](#Configure-Telegraf,-Graphite,-and-Archive)
-  - [Import Archive Metrics](#Import-Archive-Metrics)
-  - [Allow Telegraf to access PE-PostgreSQL](#Allow-Telegraf-to-access-PE-PostgreSQL)
-  - [Enable SSL](#Enable-SSL)
-  - [Profile defined types](#Profile-defined-types)
-  - [Other possibilities](#Other-possibilities)
-- [Reference](#Reference)
-- [Limitations](#Limitations)
-  - [Repository failure for InfluxDB packages](#Repository-failure-for-InfluxDB-packages)
-  - [PostgreSQL metrics collection with older versions of Telegraf](#PostgreSQL-metrics-collection-with-older-versions-of-Telegraf)
-- [Development](#Development)
+- [Description](#description)
+- [Setup](#setup)
+  - [Upgrade notes](#upgrade-notes)
+  - [Determining where Telegraf runs](#determining-where-telegraf-runs)
+  - [Requirements](#requirements)
+- [Usage](#usage)
+  - [Configure a Monolithic Master and a Dashboard node](#configure-a-monolithic-master-and-a-dashboard-node)
+  - [Manual configuration of a complex Puppet Infrastructure](#manual-configuration-of-a-complex-puppet-infrastructure)
+  - [Configure Graphite](#configure-graphite)
+  - [Configure Telegraf, Graphite, and Archive](#configure-telegraf-graphite-and-archive)
+  - [Import Archive Metrics](#import-archive-metrics)
+  - [Allow Telegraf to access PE-PostgreSQL](#allow-telegraf-to-access-pe-postgresql)
+  - [Enable SSL](#enable-ssl)
+  - [Profile defined types](#profile-defined-types)
+  - [Other possibilities](#other-possibilities)
+- [Reference](#reference)
+- [Limitations](#limitations)
+  - [Repository failure for InfluxDB packages](#repository-failure-for-influxdb-packages)
+  - [PostgreSQL metrics collection with older versions of Telegraf](#postgresql-metrics-collection-with-older-versions-of-telegraf)
+- [Development](#development)
 
 ## Description
 
@@ -40,6 +40,9 @@ You have the option of collecting metrics using any or all of the following meth
 - Via Archive files imported from the [puppetlabs/puppet_metrics_collector](https://forge.puppet.com/puppetlabs/puppet_metrics_collector) module
 
 ## Setup
+
+> In PuppetDB 6.9.1 & 5.2.13 and newer, the `/metrics/v1` endpoints are disabled by default and access to the `/metrics/v2` endpoints are restricted to localhost only in response to [CVE-2020-7943](https://nvd.nist.gov/vuln/detail/CVE-2020-7943). 
+Starting with version 2.3.0 of this module, PuppetDB metrics will not be setup by the main class if you are on the versions above or higher unless the main class is applied to the master. To collect PuppetDB metrics in other scenarios, you should use the `puppet_metrics_dashboard::profile::puppetdb` class applied to any PuppetDB nodes with the option `enable_client_cert => false` (the request will be to localhost and doen't require SSL)
 
 ### Upgrade notes
 

--- a/files/Telegraf_PuppetDB_Performance_v2.json
+++ b/files/Telegraf_PuppetDB_Performance_v2.json
@@ -1,0 +1,1065 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1553288260160,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "telegraf"
+      ],
+      "title": "",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_global_processed",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_FiveMinuteRate"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Commands Per Second",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "wps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_global_processing-time",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_95thPercentile"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Command Processing time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "95th Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "uptime",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "Heap Used",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_command_queue",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "status-service_status_experimental_jvm-metrics_heap-memory_used"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        },
+        {
+          "alias": "Heap Committed",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_command_queue",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "status-service_status_experimental_jvm-metrics_heap-memory_committed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        },
+        {
+          "alias": "uptime",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_command_queue",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "status-service_status_experimental_jvm-metrics_up-time-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Heap",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_command_queue",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetdb-status_status_queue_depth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Queue Depth",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 21
+      },
+      "id": 1,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_storage_replace-catalog-time",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_95thPercentile"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replace Catalog Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "95th Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 21
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_storage_replace-facts-time",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_95thPercentile"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replace Facts Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "95th Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb_telegraf",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "server"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "httpjson_puppetdb_storage_store-report-time",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_95thPercentile"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/$server/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Store Report Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "95th Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "telegraf",
+    "puppetdb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "influxdb_telegraf",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Telegraf PuppetDB Performance",
+  "uid": "bseUHwyiz",
+  "version": 46
+}

--- a/files/Telegraf_PuppetDB_Workload_v2.json
+++ b/files/Telegraf_PuppetDB_Workload_v2.json
@@ -1,0 +1,1191 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "telegraf"
+      ],
+      "type": "dashboards"
+    }
+  ],
+  "rows": [
+    {
+      "collapse": false,
+      "height": 257,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_global_message-persistence-time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_Mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average Command Persistence Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_Usage",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_Mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average Read Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_Wait",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_999thPercentile"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Peak Read Pool Wait",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBReadPool_pool_PendingConnections",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_Value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Read Pool Pending Connections",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_Usage",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_Mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average Write Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_Wait",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_999thPercentile"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Peak Write Pool Wait",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_PDBWritePool_pool_PendingConnections",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_Value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Write Pool Pending Connections",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_global_discarded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_OneMinuteRate"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Global Discards",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "influxdb_telegraf",
+          "fill": 1,
+          "id": 9,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "server"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "httpjson_puppetdb_global_fatal",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value_OneMinuteRate"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "distinct"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/$server/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Global Fatals",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "telegraf",
+    "puppetdb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "influxdb_telegraf",
+        "hide": 0,
+        "includeAll": true,
+        "label": "server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"host\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Telegraf PuppetDB Workload",
+  "version": 2
+}

--- a/functions/localhost_or_hosts_with_pe_profile.pp
+++ b/functions/localhost_or_hosts_with_pe_profile.pp
@@ -12,21 +12,28 @@
 function puppet_metrics_dashboard::localhost_or_hosts_with_pe_profile(
   String $profile,
 ) >> Array {
-  if $settings::storeconfigs {
-    $_profile = capitalize($profile)
-    $hosts = puppetdb_query("resources[certname] {
-      type = 'Class' and
-      title = 'Puppet_enterprise::Profile::${_profile}' and
-      nodes { deactivated is null and expired is null }
-    }").map |$nodes| { $nodes['certname'] }
+  if ($profile == 'puppetdb') and (puppet_metrics_dashboard::puppetdb_no_remote_metrics()) {
+    if $facts['puppet_server'] == $trusted['certname'] {
+      $hosts = ['localhost']
+    } else {
+      $hosts = []
+    }
   } else {
-    $hosts = []
+    if $settings::storeconfigs {
+      $_profile = capitalize($profile)
+      $hosts = puppetdb_query("resources[certname] {
+        type = 'Class' and
+        title = 'Puppet_enterprise::Profile::${_profile}' and
+        nodes { deactivated is null and expired is null }
+      }").map |$nodes| { $nodes['certname'] }
+    } else {
+      $hosts = []
+    }
+    if empty($hosts) {
+      [$trusted['certname']]
+    } else {
+      sort($hosts)
+    }
   }
 
-  if empty($hosts) {
-    [$trusted['certname']]
-  }
-  else {
-    sort($hosts)
-  }
 }

--- a/functions/puppetdb_no_remote_metrics.pp
+++ b/functions/puppetdb_no_remote_metrics.pp
@@ -1,0 +1,13 @@
+# @summary function used to determine if the metrics endpoint in PuppetDB can be reached remotely or not
+#
+# In PE 2019.5 or newer with PuppetDB 6.9.1 or newer, or PE 2018.1.13 or newer PE 2018 with PuppetDB 5.2.13 or newer
+# As per: https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
+# PuppetDB metrics in these versions can only be reached via localhost
+
+function puppet_metrics_dashboard::puppetdb_no_remote_metrics() >> Boolean {
+  if ((versioncmp($facts['puppetversion'], '6.14.0') >= 0) or ((versioncmp($facts['puppetversion'], '5.5.19') >= 0) and (versioncmp($facts['puppetversion'], '6.0.0') < 1))) {
+    true
+  } else {
+    false
+  }
+}

--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -9,6 +9,12 @@ class puppet_metrics_dashboard::dashboards::telegraf {
     default => 'http',
   }
 
+  if (( 'localhost' in $puppet_metrics_dashboard::puppetdb_list ) and puppet_metrics_dashboard::puppetdb_no_remote_metrics() ) {
+    $pdb_dash_version = '_v2'
+  } else {
+    $pdb_dash_version = undef
+  }
+
   ## This tests if the installation is PE or not.  We have a different dashboard for FOSS
   if is_function_available('pe_compiling_server_version') {
     $puppetserver_perf_template = 'Telegraf_Puppetserver_Performance.json'
@@ -25,10 +31,10 @@ class puppet_metrics_dashboard::dashboards::telegraf {
       require          => Grafana_datasource['influxdb_telegraf'],
     ;
     'Telegraf PuppetDB Performance':
-      content => file('puppet_metrics_dashboard/Telegraf_PuppetDB_Performance.json'),
+      content => file("puppet_metrics_dashboard/Telegraf_PuppetDB_Performance${pdb_dash_version}.json"),
     ;
     'Telegraf PuppetDB Workload':
-      content => file('puppet_metrics_dashboard/Telegraf_PuppetDB_Workload.json'),
+      content => file("puppet_metrics_dashboard/Telegraf_PuppetDB_Workload${pdb_dash_version}.json"),
     ;
     'Telegraf Puppetserver Performance':
       content => file("puppet_metrics_dashboard/${puppetserver_perf_template}"),

--- a/manifests/telegraf/config.pp
+++ b/manifests/telegraf/config.pp
@@ -62,11 +62,16 @@ class puppet_metrics_dashboard::telegraf::config {
     }
 
     $_puppetdb_list.each |$puppetdb| {
+      $enable_client_cert = $puppetdb['host'] ? {
+          'localhost' => false,
+          default     => true,
+        }
       puppet_metrics_dashboard::profile::puppetdb{ $puppetdb['host']:
-        puppetdb_host => $puppetdb['host'],
-        port          => $puppetdb['port'],
-        timeout       => $puppet_metrics_dashboard::http_response_timeout,
-        interval      => $puppet_metrics_dashboard::telegraf_agent_interval,
+        puppetdb_host      => $puppetdb['host'],
+        port               => $puppetdb['port'],
+        timeout            => $puppet_metrics_dashboard::http_response_timeout,
+        interval           => $puppet_metrics_dashboard::telegraf_agent_interval,
+        enable_client_cert => $enable_client_cert,
       }
     }
 
@@ -78,6 +83,10 @@ class puppet_metrics_dashboard::telegraf::config {
       }
     }
 
+    tidy { 'clean /etc/telegraf/telegraf.d':
+      path    => '/etc/telegraf/telegraf.d',
+      recurse => true,
+    }
   }
 
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,7 @@ describe 'puppet_metrics_dashboard' do
       let(:facts) do
         facts.merge(
           pe_server_version: '2019.1',
+          puppet_server: 'master.example.com',
           puppet_sslpaths: {
             certdir: {
               path: '/etc/puppetlabs/puppet/ssl/certs',
@@ -20,7 +21,7 @@ describe 'puppet_metrics_dashboard' do
         )
       end
 
-      context 'with default values for all parameters' do
+      context 'with default values for all parameters, not applied to master' do
         it { is_expected.to contain_class('puppet_metrics_dashboard') }
         it { is_expected.to contain_class('puppet_metrics_dashboard::repos') }
         it { is_expected.to contain_class('puppet_metrics_dashboard::install') }
@@ -53,7 +54,7 @@ describe 'puppet_metrics_dashboard' do
             .with_configure_telegraf(true)
             .with_consume_graphite(false)
             .with_master_list(['testhost.example.com'])
-            .with_puppetdb_list(['testhost.example.com'])
+            .with_puppetdb_list([])
             .with_influxdb_urls(['http://localhost:8086'])
             .with_telegraf_db_name('telegraf')
             .with_telegraf_agent_interval('5s')

--- a/spec/classes/telegraf/config_spec.rb
+++ b/spec/classes/telegraf/config_spec.rb
@@ -8,10 +8,12 @@ describe 'puppet_metrics_dashboard::telegraf::config' do
       end
 
       let(:facts) do
-        facts.merge(pe_server_version: '2019.1')
+        facts.merge(pe_server_version: '2019.5', puppet_server: 'testhost.example.com')
       end
 
-      context 'with defaults' do
+      let(:trusted_facts) { { 'certname' => 'testhost.example.com' } }
+
+      context 'with defaults, run on master' do
         let(:pre_condition) do
           <<-PRE_COND
             include puppet_metrics_dashboard
@@ -20,51 +22,71 @@ describe 'puppet_metrics_dashboard::telegraf::config' do
 
         it { is_expected.to contain_file('/etc/telegraf/telegraf.d/pe_last_file_sync_testhost.example.com.conf') }
         it { is_expected.to contain_file('/etc/telegraf/telegraf.d/pe_postgres_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_command_queue_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_command-parse-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_discarded_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_fatal_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_message-persistence-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_processed_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_processing-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_retried_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_retry-counts_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_seen_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_catalog_retried_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_catalog_retry-counts_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_facts_retried_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_facts_retry-counts_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_store_report_retried_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_store_reports_retry-counts_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_ActiveConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_IdleConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_PendingConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_TotalConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_Usage_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_Wait_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_ActiveConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_IdleConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_PendingConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_TotalConnections_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_Usage_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_Wait_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_add-edges_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_add-resources_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash-match-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash-miss-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-catalogs-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-environments-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-fact-paths_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-params-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-report-statuses_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_new-catalogs_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_new-catalog-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_replace-catalog-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_replace-facts-time_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_resource-hashes_testhost.example.com.conf') }
-        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_store-report-time_testhost.example.com.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_command_queue_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_command-parse-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_discarded_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_fatal_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_message-persistence-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_processed_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_processing-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_retried_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_retry-counts_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_global_seen_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_catalog_retried_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_catalog_retry-counts_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_facts_retried_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_replace_facts_retry-counts_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_store_report_retried_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_mq_store_reports_retry-counts_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_ActiveConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_IdleConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_PendingConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_TotalConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_Usage_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBReadPool_pool_Wait_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_ActiveConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_IdleConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_PendingConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_TotalConnections_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_Usage_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_PDBWritePool_pool_Wait_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_add-edges_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_add-resources_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash-match-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_catalog-hash-miss-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-catalogs-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-environments-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-fact-paths_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-params-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-report-statuses_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_gc-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_new-catalogs_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_new-catalog-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_replace-catalog-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_replace-facts-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_resource-hashes_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/puppetdb_storage_store-report-time_localhost.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_cert.pem') }
+        it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_key.pem') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.conf') }
+      end
+
+      context 'with defaults, not run on master' do
+        let(:facts) do
+          super().merge('puppet_server' => 'master.example.com')
+        end
+
+        let(:pre_condition) do
+          <<-PRE_COND
+            include puppet_metrics_dashboard
+          PRE_COND
+        end
+
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/pe_last_file_sync_testhost.example.com.conf') }
+        it { is_expected.to contain_file('/etc/telegraf/telegraf.d/pe_postgres_testhost.example.com.conf') }
+        it { is_expected.not_to contain_file('/etc/telegraf/telegraf.d/puppetdb_command_queue_localhost.conf') }
+        it { is_expected.not_to contain_file('/etc/telegraf/telegraf.d/puppetdb_command_queue_testhost.example.com.conf') }
         it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_cert.pem') }
         it { is_expected.to contain_file('/etc/telegraf/testhost.example.com_key.pem') }
         it { is_expected.to contain_file('/etc/telegraf/telegraf.conf') }

--- a/templates/telegraf.conf.epp
+++ b/templates/telegraf.conf.epp
@@ -4,6 +4,13 @@
       Array[String] $puppetdb_list,
       Array[String] $postgres_host_list,
 | -%>
+
+  <% if puppet_metrics_dashboard::puppetdb_no_remote_metrics() {
+           $metrics_version = 'v2/read'
+         } else {
+           $metrics_version = 'v1/mbeans'
+         } -%>
+
 [[inputs.httpjson]]
   name = 'puppet_stats'
   servers = [
@@ -58,7 +65,7 @@
     <%# -%>
     <% unless $puppetdb_list.empty {-%>
     <% $puppetdb_list.each |$puppetdb| {-%>
-    "https://<%= $puppetdb %>/metrics/v1/mbeans/<%= $metric['url'] %>",
+    "https://<%= $puppetdb %>/metrics/<%= $puppetdb_metrics_url %>/<%= $metric['url'] %>",
     <% } -%>
     <% } -%>
     <%# -%>


### PR DESCRIPTION
This PR addresses the changes to metrics endpoints required by CVE-2020-7943:
* Returns `['localhost']` in `localhost_or_hosts_with_pe_profile()` if `puppet_version` is greater than 6.14.0 9 or greater than 5.5.19 but below v6) when the function runs on the master. If not run on the master, an empty array is returned.
* Changes the default of `puppetdb_host` in `puppet_metrics_dashboard::profile::puppetdb` to localhost. This would be overridden when called from `puppet_metrics_dashboard::telegraf::config` when a list of puppetdb hosts is returned from `localhost_or_hosts_with_pe_profile()`
* Changes metrics URLs as appropriate
* Updates dashboards with new metric value and uses the `host` tag instead of `server` (so we don't see localhost on all the dashes). 
* Adds test coverage for running on / not running on master
* Adds a tidy resource to cleanup unmanaged dashboards