### PR TITLE
Update PE PuppetDB metrics

### DIFF
--- a/functions/puppetdb_metrics.pp
+++ b/functions/puppetdb_metrics.pp
@@ -159,7 +159,7 @@ function puppet_metrics_dashboard::puppetdb_metrics() >> Array[Hash] {
     /^2016./ =>
       $activemq_metrics + $base_metrics + $base_metrics_through_4_2 + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
     /^201[789]\./ =>
-      $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
+      $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
     default  =>
       $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
   }

--- a/functions/puppetdb_metrics.pp
+++ b/functions/puppetdb_metrics.pp
@@ -158,7 +158,7 @@ function puppet_metrics_dashboard::puppetdb_metrics() >> Array[Hash] {
       $activemq_metrics + $base_metrics + $base_metrics_through_4_2 + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
     /^2016./ =>
       $activemq_metrics + $base_metrics + $base_metrics_through_4_2 + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
-    /^201[78]\./ =>
+    /^201[789]\./ =>
       $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
     default  =>
       $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,


### PR DESCRIPTION
This changeset adds PE 2019 to the list of PuppetDB metrics so that HA sync is collected. ActiveMQ metrics are also dropped for PE 2017, 2018, and 2019 as PuppetDB switched to Stockpile in PE 2017.1.0.