### PR TITLE
PuppetDB on Compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Date TBD - Release - 2.3.x
+
+### Changes
+ - Added the `puppet_metrics_dashboard::profile::dbcompiler::install` class to mitigate CVE-2020-7943.
+
 ## 2020-4-15 - Release - 2.3.0
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ puppet_metrics_dashboard::postgres_host_list:
   - "postgres02.example.com"
 ```
 
+### Configure Master, Compiler running PuppetDB and a Dashboard node
+
+```puppet
+node 'master.example.com' {
+  include puppet_metrics_dashboard::profile::master::install
+}
+node 'dbcompiler.example.com' {
+  class { 'puppet_metrics_dashboard::profile::dbcompiler::install':
+    influxdb_urls => ["http://dashboard.example.com:8086"]
+  }
+}
+node 'dashboard.example.com' {
+  class { 'puppet_metrics_dashboard':
+    add_dashboard_examples => true,
+    overwrite_dashboards   => false,
+  }
+}
+```
+
+This will configure Telegraf, InfluxDB, and Grafana on the Dashboard node, and allow Telegraf on that host to access PuppetDB on the Compiler running PuppetDB.
+
 ### Configure Graphite
 
 ```puppet

--- a/manifests/profile/dbcompiler/install.pp
+++ b/manifests/profile/dbcompiler/install.pp
@@ -1,0 +1,65 @@
+# @summary Apply this class to compilers running PuppetDB to configure Telegraf and collect puppetserver and puppetdb metrics
+#
+# @param influxdb_urls
+#   An Array containing urls defining InfluxDB instances for Telegraf.
+#
+# @param timeout
+#   Default timeout of http calls.  Defaults to 5 seconds
+#
+# @param compiler
+#   The FQDN of the compiler / master.  Defaults to the FQDN of the server where the profile is applied
+#
+# @param puppetdb_host
+#   Where to query the puppetdb host.  Defaults to localhost.
+#
+# @param cm_port
+#   The port that the puppetserver service listens on on your compiler.  Defaults to 8140
+#
+# @param db_port
+#   The port that the puppetdb service listens on on your compiler.  Defaults to 8081
+#
+# @param interval
+#   The frequency that telegraf will poll puppetserver metrics.  Defaults to '5s'
+#
+class puppet_metrics_dashboard::profile::dbcompiler::install (
+
+  Array[String] $influxdb_urls,
+  String[2] $timeout                                          = lookup('puppet_metrics_dashboard::http_response_timeout'),
+  Variant[String,Tuple[String, Integer]] $compiler            = $facts['networking']['fqdn'],
+  Variant[String,Tuple[String, Integer]] $puppetdb_host       = 'localhost',
+  Integer[1] $cm_port                                         = 8140,
+  Integer[1] $db_port                                         = 8081,
+  String[2] $interval                                         = '5s',
+  Puppet_metrics_dashboard::Puppetdb_metric $puppetdb_metrics = puppet_metrics_dashboard::puppetdb_metrics(),
+  ){
+
+  class { 'telegraf':
+        interval => $interval,
+        logfile  => '/var/log/telegraf/telegraf.log',
+        outputs  => {
+          'influxdb' => [
+            {
+              'urls'              => $influxdb_urls,
+              'database'          => lookup(puppet_metrics_dashboard::telegraf_db_name),
+              'write_consistency' => 'any',
+              'timeout'           => '5s',
+            },
+          ],
+        },
+      }
+
+  puppet_metrics_dashboard::profile::compiler{$trusted['certname']:
+    timeout  => lookup('puppet_metrics_dashboard::http_response_timeout'),
+    compiler => $facts['networking']['fqdn'],
+    port     => $cm_port,
+    interval => $interval,
+  }
+  puppet_metrics_dashboard::profile::puppetdb{$trusted['certname']:
+    timeout            => lookup('puppet_metrics_dashboard::http_response_timeout'),
+    puppetdb_host      => $puppetdb_host,
+    puppetdb_metrics   => $puppetdb_metrics,
+    port               => $db_port,
+    interval           => $interval,
+    enable_client_cert => false,
+  }
+}


### PR DESCRIPTION
Adding role to mitigate CVE-2020-7943 for Compilers running PuppetDB.