### PR TITLE
add description to InfluxDB yumrepo

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -9,6 +9,7 @@ class puppet_metrics_dashboard::repos {
       'RedHat': {
         yumrepo {'influxdb':
           ensure   => present,
+          descr    => 'influxdb-repository',
           enabled  => 1,
           gpgcheck => 1,
           baseurl  => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -28,6 +28,7 @@ describe 'puppet_metrics_dashboard::repos' do
             is_expected.to contain_yumrepo('influxdb')
               .with(
                 'ensure' => 'present',
+                'descr' => 'influxdb-repository',
                 'enabled' => '1',
                 'gpgcheck' => '1',
                 'baseurl' => 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',


### PR DESCRIPTION
description is translated to name of the repository and yum produces
warnings when it is not defined