### PR TITLE
Fix litmus failures

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'serverspec'
 require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
-include PuppetLitmus
 
 PuppetLitmus.configure!

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'serverspec'
+include PuppetLitmus
+
 RSpec.configure do |c|
   c.mock_with :rspec
   c.before :suite do


### PR DESCRIPTION
Prior to this commit, the litmus acceptance tests were failing due to an
ordering issue. This commit moves the requires into the
spec_helper_acceptance_local.rb to comply with the current litmus
documentation.