### PR TITLE
Fix measurement names for Process dashboards

### DIFF
--- a/files/Process_System_Stats.json
+++ b/files/Process_System_Stats.json
@@ -93,7 +93,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "processes.RSS",
+          "measurement": "system_processes.RSS",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -231,7 +231,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "processes.CPU",
+          "measurement": "system_processes.CPU",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",


### PR DESCRIPTION
The metrics collector module creates measurements for system processes
named system_processes.CPU, but prior to this commit the example
dashboards used processes.CPU.  This commit fixes the discrepancy.