### PR TITLE
Make datasource for system metrics configurable

### DIFF
--- a/files/Process_System_Stats.json
+++ b/files/Process_System_Stats.json
@@ -34,7 +34,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "influxdb_puppet_metrics",
+      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -172,7 +172,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "influxdb_puppet_metrics",
+      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -310,7 +310,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "influxdb_puppet_metrics",
+      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -436,7 +436,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "influxdb_puppet_metrics",
+      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -567,9 +567,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "influxdb_puppet_metrics",
+          "value": "influxdb_puppet_metrics"
+        },
+        "hide": 0,
+        "label": "datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "influxdb_puppet_metrics",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "server",
@@ -589,7 +604,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "influxdb_puppet_metrics",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "service",


### PR DESCRIPTION
Prior to this commit, this dashboard used a hardcoded datasource
'influxdb_puppet_metrics'.  This commit makes it configurable via a
dropdown.