### PR TITLE
Enable LDAP authentication for Grafana

### DIFF
--- a/manifests/profile/ldap_auth.pp
+++ b/manifests/profile/ldap_auth.pp
@@ -1,0 +1,102 @@
+# @summary Apply this class to your dashboard node to enable LDAP authentication
+#
+## Server Parameters
+#
+# @param ldap_host
+#   FQDN or IP of the LDAP server (specify multiple hosts space separated).
+#
+# @param ldap_port
+#   The port the LDAP service is listening on. Defaults to non-secure port 389.
+#
+# @param ldap_ssl
+#   Enable the use of SSL.  Defaults to the false :: Set to true if LDAP server supports TLS
+#
+# @param ldap_tls
+#   Set to true to connect LDAP server with STARTTLS pattern. Defaults to false.
+#
+# @param ldap_ssl_skip
+#   Set to false if you do not want to skip SSL cert validation. Defaults to true.
+#
+# @param ldap_bind_dn
+#   Search user bind dn. If you can provide a single bind expression that matches all possible users, you can skip specifying ldap_bind_password.
+#
+# @param ldap_bind_password
+#   Search user bind password. If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+#
+# @param ldap_search_filter
+#   User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"
+#
+# @param ldap_search_base
+#   An array of base dns to search through
+#
+## If your LDAP server does not support the memberOf attribute add these options:
+#
+# @param ldap_groupsearch_filter
+#   Group search filter, to retrieve the groups of which the user is a member (only set if memberOf attribute is not available)
+#  
+# @param ldap_groupsearch_base
+#   An array of the base DNs to search through for groups.
+#
+# @param ldap_groupsearch_user_attr
+#   The %s in ldap_groupsearch_filter will be replaced with the attribute defined here.
+#
+## Server Attributes Parameters: Specify names of the LDAP attributes your LDAP uses.
+#
+# @param ldap_name
+#   
+# @param ldap_surname
+#
+# @param ldap_username
+#
+# @param ldap_member_of
+#
+# @param ldap_email
+#
+## Group Mapping Parameters
+#
+# @param ldap_group_dn
+#   Ldap DN of LDAP group. Will accept wildcard to match all groups "*".
+#
+# @param ldap_grafana_role
+#    Assign users one of the following roles: "Admin", "Editor" or "Viewer". Defaults to "Admin".
+#
+class puppet_metrics_dashboard::profile::ldap_auth (
+  String $ldap_host,
+  Integer $ldap_port = 389,
+  Boolean $ldap_ssl = false,
+  Boolean $ldap_tls = false,
+  Boolean $ldap_ssl_skip = true,
+  String $ldap_bind_dn,
+  String $ldap_search_filter,
+  String $ldap_search_base,
+
+  Optional[String] $ldap_bind_password = null,
+  Optional[String] $ldap_groupsearch_filter = null,
+  Optional[String] $ldap_groupsearch_base = null,
+  Optional[String] $ldap_groupsearch_user_attr = null,  
+  
+  Optional[String] $ldap_name = name,
+  Optional[String] $ldap_surname = surname,
+  Optional[String] $ldap_username = username,
+  Optional[String] $ldap_member_of = memberOf,
+  Optional[String] $ldap_email = email,
+
+  String $ldap_group_dn,
+  String $ldap_grafana_role = 'Admin',
+){
+
+  class { 'puppet_metrics_dashboard':
+    grafana_config      => {
+      'auth.ldap'       => {
+        'enabled'       => true,
+        'config_file'   => '/etc/grafana/ldap.toml',
+        'allow_sign_up' => true,
+      },
+    },
+  }
+  file { '/etc/grafana/ldap.toml':
+    ensure => present,
+    content => epp('puppet_metrics_dashboard/ldap.toml.epp'),
+    notify  => Service['grafana-server'],
+  }  
+}

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -12,6 +12,12 @@ class puppet_metrics_dashboard::profile::master::install {
     $puppetserver_service = 'puppetserver'
   }
 
+  package { 'toml':
+    ensure   => present,
+    provider => 'puppetserver_gem',
+    notify   => Service[$puppetserver_service],
+  }
+
   package { 'toml-rb':
     ensure   => present,
     provider => 'puppetserver_gem',

--- a/templates/ldap.toml.epp
+++ b/templates/ldap.toml.epp
@@ -1,0 +1,27 @@
+# This file is managed by Puppet. Manual changes will be overwritten during the next puppet run.
+# To make changes, update the parameters for the puppet_metrics_dashboard::profile::ldap_auth class.
+
+[[servers]]
+host = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_host %>"
+port = <%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_port %>
+use_ssl = <%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_ssl %>
+start_tls = <%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_tls %>
+ssl_skip_verify = <%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_ssl_skip %>
+bind_dn = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_bind_dn %>"
+bind_password = '<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_bind_password %>'
+search_filter = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_search_filter %>"
+search_base_dns = ["<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_search_base %>"]
+group_search_filter = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_groupsearch_filter %>"
+group_search_base_dns = ["<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_groupsearch_base %>"]
+group_search_filter_user_attribute = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_groupsearch_user_attr %>"
+
+[servers.attributes]
+name = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_name %>"
+surname = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_surname %>"
+username = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_username %>"
+member_of = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_member_of %>"
+email =  "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_email %>"
+
+[[servers.group_mappings]]
+group_dn = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_group_dn %>"
+org_role = "<%= $puppet_metrics_dashboard::profile::ldap_auth::ldap_grafana_role %>"


### PR DESCRIPTION
Created ldap_auth.pp to enable LDAP authentication to the dashboard.
Modified profile::master::install to install toml gem.
Created ldap.toml.epp template for LDAP config.