### PR TITLE
Use supplied compiler name in dbcompiler

### DIFF
--- a/manifests/profile/dbcompiler/install.pp
+++ b/manifests/profile/dbcompiler/install.pp
@@ -50,7 +50,7 @@ class puppet_metrics_dashboard::profile::dbcompiler::install (
 
   puppet_metrics_dashboard::profile::compiler{$trusted['certname']:
     timeout  => lookup('puppet_metrics_dashboard::http_response_timeout'),
-    compiler => $facts['networking']['fqdn'],
+    compiler => $compiler,
     port     => $cm_port,
     interval => $interval,
   }


### PR DESCRIPTION
Honor the value passed in for 'compiler' if specified. This
profile is intended to be used on compilers which are running
PuppetDB along with Puppetserver so using the same value
should work and, in the default case, the behavior is unchanged.