### PR TITLE
(GH-115) Pin spec testing modules to a version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,11 +3,15 @@ fixtures:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     apt: https://github.com/puppetlabs/puppetlabs-apt.git
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
-    grafana: https://github.com/voxpupuli/puppet-grafana.git
+    grafana:
+      repo: https://github.com/voxpupuli/puppet-grafana.git
+      ref: v7.0.0
     yumrepo:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"
-    telegraf: https://github.com/voxpupuli/puppet-telegraf.git
+    telegraf:
+      repo: https://github.com/voxpupuli/puppet-telegraf.git
+      ref: v3.1.0
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
     provision: https://github.com/puppetlabs/provision.git

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 3.0.0 < 7.0.0"
+      "version_requirement": ">= 3.0.0 < 8.0.0"
     },
     {
       "name": "puppet-telegraf",


### PR DESCRIPTION
Prior to this commit, the modules in the fixtures.yml were on the master
branch. As this can introduce issues during spec testing, this commit
pins the puppet modules to the latest versions.

This alleviates #115 in the short term.