### PR TITLE
Detect new cert_allowlist_entry class

### DIFF
--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -60,23 +60,22 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
       $postgres_version = '9.4'
     }
 
+    $telegraf_allow_settings = {
+      'user'                          => 'telegraf',
+      'database'                      => 'pe-puppetdb',
+      'allowed_client_certname'       => $_telegraf_host,
+      'pg_ident_conf_path'            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
+      'ip_mask_allow_all_users_ssl'   => '0.0.0.0/0',
+      'ipv6_mask_allow_all_users_ssl' => '::/0',
+    }
+
     if defined(puppet_enterprise::pg::cert_allowlist_entry) {
       puppet_enterprise::pg::cert_allowlist_entry { 'allow-telegraf-access':
-        user                          => 'telegraf',
-        database                      => 'pe-puppetdb',
-        allowed_client_certname       => $_telegraf_host,
-        pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
-        ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
-        ipv6_mask_allow_all_users_ssl => '::/0',
+        * => $telegraf_allow_settings,
       }
     } else {
       puppet_enterprise::pg::cert_whitelist_entry { 'allow-telegraf-access':
-        user                          => 'telegraf',
-        database                      => 'pe-puppetdb',
-        allowed_client_certname       => $_telegraf_host,
-        pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
-        ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
-        ipv6_mask_allow_all_users_ssl => '::/0',
+        * => $telegraf_allow_settings,
       }
     }
 

--- a/manifests/profile/master/postgres_access.pp
+++ b/manifests/profile/master/postgres_access.pp
@@ -60,13 +60,24 @@ class puppet_metrics_dashboard::profile::master::postgres_access (
       $postgres_version = '9.4'
     }
 
-    puppet_enterprise::pg::cert_whitelist_entry { 'allow-telegraf-access':
-      user                          => 'telegraf',
-      database                      => 'pe-puppetdb',
-      allowed_client_certname       => $_telegraf_host,
-      pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
-      ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
-      ipv6_mask_allow_all_users_ssl => '::/0',
+    if defined(puppet_enterprise::pg::cert_allowlist_entry) {
+      puppet_enterprise::pg::cert_allowlist_entry { 'allow-telegraf-access':
+        user                          => 'telegraf',
+        database                      => 'pe-puppetdb',
+        allowed_client_certname       => $_telegraf_host,
+        pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
+        ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
+        ipv6_mask_allow_all_users_ssl => '::/0',
+      }
+    } else {
+      puppet_enterprise::pg::cert_whitelist_entry { 'allow-telegraf-access':
+        user                          => 'telegraf',
+        database                      => 'pe-puppetdb',
+        allowed_client_certname       => $_telegraf_host,
+        pg_ident_conf_path            => "/opt/puppetlabs/server/data/postgresql/${postgres_version}/data/pg_ident.conf",
+        ip_mask_allow_all_users_ssl   => '0.0.0.0/0',
+        ipv6_mask_allow_all_users_ssl => '::/0',
+      }
     }
 
   }


### PR DESCRIPTION
PE 2019.8.3 introduces the `puppet_enterprise::pg::cert_allowlist_entry` class and deprecates the `puppet_enterprise::pg::cert_whitelist_entry` class. This PR updates the code in this module to correctly handle that change.