### PR TITLE
(SUP-2007) Add local import and viewing of metrics

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,4 +14,8 @@ fixtures:
       ref: v3.1.0
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
-    provision: https://github.com/puppetlabs/provision.git
+      #    provision: https://github.com/puppetlabs/provision.git
+    provision:
+      repo: https://github.com/jarretlavallee/provision.git
+      branch: gh_142
+    puppet_metrics_collector: https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector.git

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,8 +14,5 @@ fixtures:
       ref: v3.1.0
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
-      #    provision: https://github.com/puppetlabs/provision.git
-    provision:
-      repo: https://github.com/jarretlavallee/provision.git
-      branch: gh_142
+    provision: https://github.com/puppetlabs/provision.git
     puppet_metrics_collector: https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector.git

--- a/provision.yaml
+++ b/provision.yaml
@@ -14,3 +14,11 @@ travis_el:
 release_checks:
   provisioner: vmpooler
   images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']
+viewer:
+  provisioner: docker
+  images: ['litmusimage/centos:7']
+    #vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000"]}'
+  vars:
+    docker_run_opts:
+      - "-p 8086:8086"
+      - "-p 3000:3000"

--- a/provision.yaml
+++ b/provision.yaml
@@ -18,7 +18,3 @@ viewer:
   provisioner: docker
   images: ['litmusimage/centos:7']
   vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000"]}'
-    #vars:
-    #  docker_run_opts:
-    #    - "-p 8086:8086"
-    #    - "-p 3000:3000"

--- a/provision.yaml
+++ b/provision.yaml
@@ -17,8 +17,8 @@ release_checks:
 viewer:
   provisioner: docker
   images: ['litmusimage/centos:7']
-    #vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000"]}'
-  vars:
-    docker_run_opts:
-      - "-p 8086:8086"
-      - "-p 3000:3000"
+  vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000"]}'
+    #vars:
+    #  docker_run_opts:
+    #    - "-p 8086:8086"
+    #    - "-p 3000:3000"

--- a/rakelib/viewer.rake
+++ b/rakelib/viewer.rake
@@ -1,0 +1,69 @@
+namespace :viewer do
+  # Provision the `viewer` node from the `provision.yaml` and install the dashboard
+  # Note that this will bind to ports 3000 and 8086 on the local machine
+  # Ensure that there are not other litmus machines present when running this task
+  desc 'Provisions a local metrics dashboard instance'
+  task :provision do
+    require 'puppet_litmus'
+    require 'bolt_spec/run'
+
+    puts 'Provisioning the node'
+    Rake::Task['litmus:provision_install'].invoke('viewer', 'puppet6')
+
+    inventory_hash = PuppetLitmus::InventoryManipulation.inventory_hash_from_inventory_file
+    targets = PuppetLitmus::InventoryManipulation.find_targets(inventory_hash, nil)
+    machine_name = targets.first unless targets.nil?
+
+    puts 'Preparing the node'
+    result = BoltSpec::Run.run_command('puppet resource package toml-rb ensure=installed provider=puppet_gem', machine_name, inventory: inventory_hash.clone)
+    raise "Failed to install toml-rb on the node: #{result}" unless result.first['status'] == 'success'
+
+    puts 'Applying the dashboard class. This may take a while'
+    manifest = 'class{"puppet_metrics_dashboard":
+      add_dashboard_examples => true,
+      overwrite_dashboards => false,
+      configure_telegraf => false,
+      enable_telegraf => false,
+      influxdb_database_name => ["puppet_metrics"]
+    }'
+    config_data = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
+    BoltSpec::Run.apply_manifest(manifest, machine_name, execute: true, config: config_data, inventory: inventory_hash.clone)
+    result = BoltSpec::Run.apply_manifest(manifest, machine_name, execute: true, config: config_data, inventory: inventory_hash.clone)
+    raise "Failed to install the dashboard : #{result}" unless result.first['status'] == 'success'
+
+    puts 'The dashboard is available on http://localhost:3000 and data can be imported in http://localhost:8086'
+    puts 'The default login is admin:admin'
+  end
+
+  # Import metrics into the provisioned dashboard
+  # Takes a parameter of the file location on disk of the metrics directory
+  # Taks a second parameter of the number of days to load. Defaults to 30.
+  desc 'Imports metrics data into a local metrics dashboard instance'
+  task :import, [:metrics_location, :days] do |_t, args|
+    require 'open3'
+    raise 'Cannot find metrics directory' unless File.directory?(args[:metrics_location])
+
+    # Ensure that the puppet_metrics_collector module has been installed into fixtures.
+    Rake::Task['spec_prep'].invoke
+
+    script_args = "--pattern \"#{args[:metrics_location]}/**/*.json\" --netcat 127.0.0.1 --convert-to influxdb --influx-db puppet_metrics"
+    script_path = File.join(Dir.pwd, 'spec', 'fixtures', 'modules', 'puppet_metrics_collector', 'files', 'json2timeseriesdb')
+    raise 'Cannot find json2timeseriesdb' unless File.file?(script_path)
+
+    puts 'Importing metrics. This will take a while, but metrics will populate the in the dashboard during this time. Only STDERR will be displayed'
+    Open3.popen3("ruby #{script_path} #{script_args}") do |stdout, stderr, status, thread|
+      puts stderr.read
+    end
+  end
+
+  desc 'Destroys metrics dashboard instance'
+  task :destroy do
+    puts 'Destroying the node'
+    Rake::Task['litmus:tear_down'].invoke
+  end
+end
+
+task :viewer, [:metrics_location, :days] do |_t, args|
+  Rake::Task['viewer:provision'].invoke
+  Rake::Task['viewer:import'].invoke(args[:metrics_location], args[:days])
+end


### PR DESCRIPTION
This PR ports the functionality of https://github.com/puppetlabs/puppet-metrics-viewer into this repository in an effort to archive https://github.com/puppetlabs/puppet-metrics-viewer. The viewer functionality is provided by new rake tasks which use Litmus and bolt to spin up a local docker container with the dashboard. The metrics from a local directory are then imported into the docker dashboard instance.

This PR adds a new module to the fixtures to be able to import the data into the local dashboard container. 

There are some additional benefits from this functionality

* View a temporary copy of the 'puppet_metrics' dashboards
* Develop dashboards on an ephemeral instance
* Import offline data into the ephemeral instance

**Usage**

There 4 new rake tasks to perform tasks

```
rake viewer[metrics_location,retention_days]                                                               # Provisions a local dashboard instance and imports the metrics data
rake viewer:destroy                                                                                        # Destroys metrics dashboard instance
rake viewer:import[metrics_location,retention_days]                                                        # Imports metrics data into a local metrics dashboard instance
rake viewer:provision                                                                                      # Provisions a local metrics dashboard instance
```

Spin up a new instance and import 10 days of metrics from a path. 

```
bundle exec rake 'viewer[/path/to/metrics,10]'
```

Destroy the instance

```
bundle exec rake viewer:destroy
```

Spin up a new instance with the dashboard

```
bundle exec rake viewer:provision
```

Import metrics into an existing instance

```
bundle exec rake viewer:import[/path/to/metrics,30]
```