### PR TITLE
Remove slash from dashboard name

### DIFF
--- a/manifests/dashboards/puppet_metrics.pp
+++ b/manifests/dashboards/puppet_metrics.pp
@@ -41,7 +41,7 @@ class puppet_metrics_dashboard::dashboards::puppet_metrics {
     'Archive Postgres Performance':
       content => file('puppet_metrics_dashboard/Archive_Postgres.json'),
     ;
-    'Archive Process/System Stats':
+    'Archive Process-System Stats':
       content => file('puppet_metrics_dashboard/Process_System_Stats.json'),
     ;
     'Archive File Sync Metrics':

--- a/spec/classes/dashboards/puppet_metrics_spec.rb
+++ b/spec/classes/dashboards/puppet_metrics_spec.rb
@@ -72,8 +72,8 @@ describe 'puppet_metrics_dashboard::dashboards::puppet_metrics' do
         )
       end
 
-      it 'should contain Grafana_dashboard[Archive Process/System Stats]' do
-        is_expected.to contain_grafana_dashboard('Archive Process/System Stats').with(
+      it 'should contain Grafana_dashboard[Archive Process-System Stats]' do
+        is_expected.to contain_grafana_dashboard('Archive Process-System Stats').with(
           grafana_url: 'http://localhost:3000',
           grafana_user: 'admin',
           grafana_password: 'puppetlabs',


### PR DESCRIPTION
Using a slash in a title of a `grafana_dashboard` resource
leads to errors when Puppet tries to manage the dashboard.