### PR TITLE
(maint) Increase dependency versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,13 +5,11 @@ fixtures:
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     grafana:
       repo: https://github.com/voxpupuli/puppet-grafana.git
-      ref: v7.0.0
     yumrepo:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"
     telegraf:
       repo: https://github.com/voxpupuli/puppet-telegraf.git
-      ref: v3.1.0
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
     provision: https://github.com/puppetlabs/provision.git

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 3.0.0 < 8.0.0"
+      "version_requirement": ">= 3.0.0 < 9.0.0"
     },
     {
       "name": "puppet-telegraf",
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.3.0 < 8.0.0"
+      "version_requirement": ">= 4.3.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-puppetserver_gem",
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 1.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this PR, there were several major versions of dependency
modules that were released, but not compatible with this module. This
commit increases the maximum version of the dependencies for this
module.

This does not increase puppet-telegraf due to incompatibilities in 4.0.0. There is a commit that will fix this in the next release.