### PR TITLE
(#151) Install toml gem by default.

### DIFF
--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -5,14 +5,17 @@
 # @example Apply this class to the Master and any/all Compilers
 #   include puppet_metrics_dashboard::profile::master::install
 #
-class puppet_metrics_dashboard::profile::master::install {
+class puppet_metrics_dashboard::profile::master::install (
+  Boolean $manage_ldap_auth = true,
+  ) {
+
   if $facts['pe_server_version'] {
     $puppetserver_service = 'pe-puppetserver'
   } else {
     $puppetserver_service = 'puppetserver'
   }
 
-  if $puppet_metrics_dashboard::enable_ldap_auth {
+  if $manage_ldap_auth {
     package { 'toml':
       ensure   => present,
       provider => 'puppetserver_gem',

--- a/spec/classes/profile/master/install_spec.rb
+++ b/spec/classes/profile/master/install_spec.rb
@@ -26,6 +26,23 @@ describe 'puppet_metrics_dashboard::profile::master::install' do
             .with_ensure('present')
         end
       end
+
+      context 'manage_ldap_auth false' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            service { 'pe-puppetserver': ensure => running }
+          PRE_COND
+        end
+        let(:params) { { 'manage_ldap_auth' => false } }
+
+        it do
+          is_expected.not_to contain_package('toml')
+        end
+        it do
+          is_expected.to contain_package('toml-rb')
+            .with_ensure('present')
+        end
+      end
     end
   end
 end

--- a/spec/classes/profile/master/install_spec.rb
+++ b/spec/classes/profile/master/install_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+describe 'puppet_metrics_dashboard::profile::master::install' do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
+      let(:node) do
+        'testhost.example.com'
+      end
+      let(:facts) do
+        facts.merge(pe_server_version: '2019.8.6')
+      end
+
+      context 'with defaults' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            service { 'pe-puppetserver': ensure => running }
+          PRE_COND
+        end
+        let(:params) { { 'manage_ldap_auth' => true } }
+
+        it do
+          is_expected.to contain_package('toml')
+            .with_ensure('present')
+        end
+        it do
+          is_expected.to contain_package('toml-rb')
+            .with_ensure('present')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes to puppet_metrics_collector::profile::master::install to manage the toml gem required for LDAP authentication. This change will address issue #151.