### PR TITLE
(SUP-2500) Remove Harmful Technology - Readme and Reference

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,13 +5,11 @@ fixtures:
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     grafana:
       repo: https://github.com/voxpupuli/puppet-grafana.git
-      ref: v7.0.0
     yumrepo:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"
     telegraf:
       repo: https://github.com/voxpupuli/puppet-telegraf.git
-      ref: v3.1.0
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
     provision: https://github.com/puppetlabs/provision.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,7 +34,7 @@
 ### Defined types
 
 * [`puppet_metrics_dashboard::certs`](#puppet_metrics_dashboardcerts): This class creates a certificates for Grafana and for connecting to PE Postgres.
-* [`puppet_metrics_dashboard::profile::compiler`](#puppet_metrics_dashboardprofilecompiler): Apply this class to a master or compiler to collect puppetserver metrics
+* [`puppet_metrics_dashboard::profile::compiler`](#puppet_metrics_dashboardprofilecompiler): Apply this class to a primary server or compiler to collect puppetserver metrics
 * [`puppet_metrics_dashboard::profile::master::postgres`](#puppet_metrics_dashboardprofilemasterpostgres): Apply this class to an agent running pe-postgresql to collect postgres metrics
 * [`puppet_metrics_dashboard::profile::puppetdb`](#puppet_metrics_dashboardprofilepuppetdb): Apply this class to a node running puppetdb to collect puppetdb metrics
 
@@ -73,7 +73,7 @@ class { 'puppet_metrics_dashboard':
 }
 ```
 
-##### Configure Telegraf to collect metrics from a list of Masters, PuppetDB, and PostgreSQL servers
+##### Configure Telegraf to collect metrics from a list of Primary Server and Compilers, PuppetDB, and PostgreSQL servers
 
 ```puppet
 class { 'puppet_metrics_dashboard':
@@ -87,7 +87,7 @@ class { 'puppet_metrics_dashboard':
 }
 ```
 
-##### Configure Graphite to accept metrics from a list of Masters
+##### Configure Graphite to accept metrics from a list of Primary Server and Compilers
 
 ```puppet
 class { 'puppet_metrics_dashboard':
@@ -421,7 +421,7 @@ Default value: `lookup('puppet_metrics_dashboard::http_response_timeout')`
 
 Data type: `Variant[String,Tuple[String, Integer]]`
 
-The FQDN of the compiler / master.  Defaults to the FQDN of the server where the profile is applied
+The FQDN of the compiler / primary server.  Defaults to the FQDN of the server where the profile is applied
 
 Default value: `$facts['networking']['fqdn']`
 
@@ -663,7 +663,7 @@ Install requirements for the voxpupuli/puppet-telegraf module.
 
 #### Examples
 
-##### Apply this class to the Master and any/all Compilers
+##### Apply this class to the Primary Server and any/all Compilers
 
 ```puppet
 include puppet_metrics_dashboard::profile::master::install
@@ -741,11 +741,11 @@ Default value: `$name`
 
 ### <a name="puppet_metrics_dashboardprofilecompiler"></a>`puppet_metrics_dashboard::profile::compiler`
 
-Apply this class to a master or compiler to collect puppetserver metrics
+Apply this class to a primary server or compiler to collect puppetserver metrics
 
 #### Examples
 
-##### Add telegraf to a master / compiler
+##### Add telegraf to a primary server / compiler
 
 ```puppet
 puppet_metrics_dashboard::profile::compiler{ $facts['networking']['fqdn']:
@@ -774,7 +774,7 @@ Default value: `lookup('puppet_metrics_dashboard::http_response_timeout')`
 
 Data type: `Variant[String,Tuple[String, Integer]]`
 
-The FQDN of the compiler / master.  Defaults to the FQDN of the server where the profile is applied
+The FQDN of the compiler / primary server.  Defaults to the FQDN of the server where the profile is applied
 
 Default value: `$facts['networking']['fqdn']`
 

--- a/manifests/profile/master/install.pp
+++ b/manifests/profile/master/install.pp
@@ -5,14 +5,17 @@
 # @example Apply this class to the Master and any/all Compilers
 #   include puppet_metrics_dashboard::profile::master::install
 #
-class puppet_metrics_dashboard::profile::master::install {
+class puppet_metrics_dashboard::profile::master::install (
+  Boolean $manage_ldap_auth = true,
+  ) {
+
   if $facts['pe_server_version'] {
     $puppetserver_service = 'pe-puppetserver'
   } else {
     $puppetserver_service = 'puppetserver'
   }
 
-  if $puppet_metrics_dashboard::enable_ldap_auth {
+  if $manage_ldap_auth {
     package { 'toml':
       ensure   => present,
       provider => 'puppetserver_gem',

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 3.0.0 < 8.0.0"
+      "version_requirement": ">= 3.0.0 < 9.0.0"
     },
     {
       "name": "puppet-telegraf",
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.3.0 < 8.0.0"
+      "version_requirement": ">= 4.3.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-puppetserver_gem",
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 1.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/profile/master/install_spec.rb
+++ b/spec/classes/profile/master/install_spec.rb
@@ -26,6 +26,23 @@ describe 'puppet_metrics_dashboard::profile::master::install' do
             .with_ensure('present')
         end
       end
+
+      context 'manage_ldap_auth false' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            service { 'pe-puppetserver': ensure => running }
+          PRE_COND
+        end
+        let(:params) { { 'manage_ldap_auth' => false } }
+
+        it do
+          is_expected.not_to contain_package('toml')
+        end
+        it do
+          is_expected.to contain_package('toml-rb')
+            .with_ensure('present')
+        end
+      end
     end
   end
 end

--- a/spec/classes/profile/master/install_spec.rb
+++ b/spec/classes/profile/master/install_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+describe 'puppet_metrics_dashboard::profile::master::install' do
+  on_supported_os.each do |os, facts|
+    context "with facter #{RSpec.configuration.default_facter_version} on #{os}" do
+      let(:node) do
+        'testhost.example.com'
+      end
+      let(:facts) do
+        facts.merge(pe_server_version: '2019.8.6')
+      end
+
+      context 'with defaults' do
+        let(:pre_condition) do
+          <<-PRE_COND
+            service { 'pe-puppetserver': ensure => running }
+          PRE_COND
+        end
+        let(:params) { { 'manage_ldap_auth' => true } }
+
+        it do
+          is_expected.to contain_package('toml')
+            .with_ensure('present')
+        end
+        it do
+          is_expected.to contain_package('toml-rb')
+            .with_ensure('present')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Change the harmful terminology per:

blacklist > blocklist
compile master > compiler
high availability > disaster recovery
master of masters > primary server
master > primary server
master (branch) > main (branch)
monolithic > standard (but you might mean all supported architectures: https://support.puppet.com/hc/en-us/articles/360037742154-Architecture-terminology-changes-in-Puppet-Enterprise-2019-2)
whitelist > allowlist

Most of the terms discovered and changed were `master` -> `primary server` and `masters` -> `primary server and compilers`