### PR TITLE
(SUP-2568) Only auto release if the changelog is updated

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -48,8 +48,14 @@ jobs:
       run: |
         echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
 
-    - name: "Commit changes"
+    - name: "Check if a release is necessary"
       if: ${{ github.repository_owner == 'puppetlabs' }}
+      id: check
+      run: |
+        git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+
+    - name: "Commit changes"
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
         git config --local user.name "GitHub Action"
@@ -59,18 +65,23 @@ jobs:
     - name: Create Pull Request
       id: cpr
       uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
         branch: "release-prep"
         delete-branch: true
         title: "Release prep v${{ steps.gv.outputs.ver }}"
-        body: "Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}"
+        body: |
+          Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}. 
+          Please verify before merging:
+          - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
+          - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
+          - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
         labels: "maintenance"
 
     - name: PR outputs
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Prior to this commit, the auto release workflow would always result in a
commit and PR. This commit updates the logic to only make the PR if the
changelog is updated.