### PR TITLE
(GH-158) Add support for puppet-telegraf 4.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ yum install curl nss --disablerepo influxdb
 
 PostgreSQL metrics collection requires Telegraf version 1.9.1 or later.
 
+### Puppet-Telegraf module version 4.0.0
+
+This module is not compatible with `puppet-telegraf` version 4.0.0. Please use 3.x or 4.1+. See (#158)[https://github.com/puppetlabs/puppet_metrics_dashboard/issues/158] for more details.
+
 ## Development
 
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-telegraf",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
Prior to this PR, this module supported < 4.0.0 of the
puppet-telegraf module. This PR allows 4.x support now that 4.1.0 is
compatible with this module.

Resolves #158 