### PR TITLE
(GH-172) Add cgroup mapping for viewer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Provision test environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platforms.image }}' -- bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]'
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platforms.image }}' -- bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }},{docker_run_opts: ["-v /sys/fs/cgroup:/sys/fs/cgroup:ro"]}]'
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Provision test environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platforms.image }}' -- bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]'
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platforms.image }}' -- bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }},{docker_run_opts: ["-v /sys/fs/cgroup:/sys/fs/cgroup:ro"]}]'
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo

--- a/provision.yaml
+++ b/provision.yaml
@@ -20,4 +20,4 @@ release_checks:
 viewer:
   provisioner: docker
   images: ['litmusimage/centos:7']
-  vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000"]}'
+  vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000", "-v /sys/fs/cgroup:/sys/fs/cgroup:ro"]}'

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -18,7 +18,7 @@ RSpec.configure do |c|
         provider => puppet_gem,
       }
       if $facts['os']['family'] == 'Debian' {
-        package{['lsb-release','iproute2']:
+        package{['lsb-release','iproute2','curl']:
           ensure => installed,
         }
       }


### PR DESCRIPTION
Prior to this commit, the local viewer was failing during the start of
influxdb. This commit adds a cgroup mapping into the container so that
systemd can read the cgroups.

Fixes #172 