### PR TITLE
(SUP-2764) Remove EOL OS versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,24 +38,21 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "8",
-        "7",
-        "6"
+        "7"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "9",
-        "8"
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8",
-        "7",
-        "6"
+        "7"
       ]
     },
     {

--- a/provision.yaml
+++ b/provision.yaml
@@ -7,16 +7,16 @@ vagrant:
   images: ['centos/7', 'generic/ubuntu1804']
 travis_deb_legacy:
   provisioner: docker
-  images: ['litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/debian:8', 'litmusimage/debian:9']
+  images: ['litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/debian:9']
 travis_deb:
   provisioner: docker
   images: ['litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/ubuntu:20.04', 'litmusimage/debian:9', 'litmusimage/debian:10']
 travis_el:
   provisioner: docker
-  images: ['litmusimage/centos:6', 'litmusimage/centos:7' ]
+  images: ['litmusimage/centos:7']
 release_checks:
   provisioner: vmpooler
-  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']
+  images: ['redhat-7-x86_64', 'redhat-8-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'oracle-7-x86_64', 'scientific-7-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']
 viewer:
   provisioner: docker
   images: ['litmusimage/centos:7']


### PR DESCRIPTION
Removes EOL OSes including:
- Centos 6
- Redhat 6
- Scientific Linux 6
- Oracle 6
- Debian 8