### PR TITLE
Enable PuppetDB SSL in dbcompiler profile

### DIFF
--- a/manifests/profile/dbcompiler/install.pp
+++ b/manifests/profile/dbcompiler/install.pp
@@ -68,7 +68,7 @@ class puppet_metrics_dashboard::profile::dbcompiler::install (
     puppetdb_metrics   => $puppetdb_metrics,
     port               => $db_port,
     interval           => $interval,
-    enable_client_cert => false,
+    enable_client_cert => true,
   }
 
   if $tidy_telegraf_configs {

--- a/spec/classes/profile/dbcompiler/install_spec.rb
+++ b/spec/classes/profile/dbcompiler/install_spec.rb
@@ -42,7 +42,7 @@ describe 'puppet_metrics_dashboard::profile::dbcompiler::install' do
             puppetdb_metrics: [{ 'name' => 'metric_name', 'url' => 'metrics_url' }],
             port: 8081,
             interval: '5s',
-            enable_client_cert: false,
+            enable_client_cert: true,
           )
         end
         it 'does not contain a tidy resource' do


### PR DESCRIPTION
This commit updates `puppet_metrics_dashboard::profile::dbcompiler::install`
to pass `enable_client_cert => true` when configuring PuppetDB metrics.
This parameter controls whether `http://` or `https://` is used as the
collection scheme.

As the default port number queried is 8081, which is the SSL port, `https://`
must be used. Additionally, client certificates must be use to authorize
access to the `/status` and `/metrics` API endpoints due to CVE-2020-7943.