### PR TITLE
Accept 503 responses from PE /status APIs

### DIFF
--- a/manifests/profile/compiler.pp
+++ b/manifests/profile/compiler.pp
@@ -32,6 +32,9 @@ define puppet_metrics_dashboard::profile::compiler (
       'urls'                 => [ "https://${compiler}:${port}/status/v1/services?level=debug" ],
       'method'               => 'GET',
       'insecure_skip_verify' => true,
+      # The /status/v1 API will respond with a 503 code if a single
+      # sub-service is in an unhealthy state, but will still return metrics.
+      'success_status_codes' => [200, 503],
       'timeout'              => $timeout,
       'tags'                 => {
         'server' => $compiler,
@@ -49,6 +52,7 @@ if $facts['pe_server_version'] {
         'insecure_skip_verify' => true,
         'data_format'          => 'json',
         'json_string_fields'   => ['status_repos_puppet-code_latest_commit_date'],
+        'success_status_codes' => [200, 503],
         'timeout'              => $timeout,
       }],
       notify      => Service['telegraf'],

--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -94,6 +94,9 @@ define puppet_metrics_dashboard::profile::puppetdb (
       'data_format'   => 'json',
       'name_override' => 'httpjson_puppetdb_command_queue',
       'urls'          => [ "${protocol}://${puppetdb_host}:${port}/status/v1/services?level=debug" ],
+      # The /status/v1 API will respond with a 503 code if a single
+      # sub-service is in an unhealthy state, but will still return metrics.
+      'success_status_codes' => [200, 503],
       'timeout'       => $timeout,
       'tags'          => {
         'server' => $server_name,


### PR DESCRIPTION
The puppetlabs/trapperkeeper-status library that provides the
`/status/v1` API of various PE services will respond with a
HTTP 503 status code if any sub-service is not in a healthy state.
By default, Telegraf HTTP inputs will only accept 200 as a
successful response code. This state of affairs leads to situations
like an outage in `pe-orchestration-services` resulting in Telegraf
rejecting perfectly good JRuby metrics from `pe-puppetserver` on
compilers because the `pcp-broker` sub-service is unhealthy.

This commit updates the Telegraf configuration to accept HTTP 503
as a successful return code in addition to 200 so that an attempt
is made to process and store metrics data during outages of external
services.