### PR TITLE
Allow ssl_dir to be configured via Hiera

### DIFF
--- a/manifests/certs.pp
+++ b/manifests/certs.pp
@@ -1,17 +1,23 @@
-# @summary This class creates a certificates for Grafana and for connecting to PE Postgres.
+# @summary Copy Puppet Agent keypair for use by metric services.
 #
-# This class creates a set of certificates in /etc/${service}. These certificates
-# are used when configuring Grafana to use SSL and to connect to PE Postgres.
-# The certificates are based on the agent's own Puppet certificates.
+# This type creates copies of the Puppet Agent's SSL keypair in `/etc/${service}`
+# with user+group ownership set to `${service}`. These certificates are used
+# when configuring Grafana to use SSL and to connect Telegraf with PE Services.
 #
 # @param service
-#   The service name associated with these certificates.
+#   The service name to associate with the keypair copy.
 #
-define puppet_metrics_dashboard::certs(
-  $service = $name
+# @param ssl_dir
+#   The directory to copy Puppet Agent SSL files from. Defaults to the
+#   value of `puppet config print --section server ssldir` used by the
+#   Puppet Server, often `/etc/puppetlabs/puppet/ssl`. Use Hiera to
+#   override this value if agents have a different `ssldir` setting
+#   or if `bolt apply` is being used.
+define puppet_metrics_dashboard::certs (
+  $service = $name,
+  $ssl_dir = lookup('puppet_metrics_dashboard::certs::ssl_dir',
+                    {default_value => $settings::ssldir}),
 ){
-
-  $ssl_dir        = $settings::ssldir
   $cert_dir       = "/etc/${service}"
   $client_pem_key = "${ssl_dir}/private_keys/${trusted['certname']}.pem"
   $client_cert    = "${ssl_dir}/certs/${trusted['certname']}.pem"


### PR DESCRIPTION
This commit updates the `puppet_metrics_dashboard::certs` defined type
by promoting the `ssl_dir` variable to be a parameter. The default
value remains `$settings::ssldir`, but can be overridden by Hiera.

This change provides users the option to work around two situations
where `$settings::ssldir` does not point to the right location:

 - `$settings::ssldir` returns the SSL directory of the _Puppet Server_
   or other process compiling the catalog. This is usually-but-not-always
   the same directory that the Puppet Agent applying the catalog stores
   its keypair in.

 - Bolt's `bolt apply` command runs a `puppet apply` process on remote
   targets with many major Puppet settings, such as `ssldir`, shifted
   into a tempdir sandbox to avoid the possibility of side-effects
   that could affect Puppet daemons.

Fixes puppetlabs/puppet_metrics_dashboard#183