### PR TITLE
(SUP-2923) Replace unencrypted git protocol in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,22 +1,21 @@
 fixtures:
   repositories:
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
-    apt: https://github.com/puppetlabs/puppetlabs-apt.git
-    inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
-    grafana: https://github.com/voxpupuli/puppet-grafana.git
-    archive: https://github.com/voxpupuli/puppet-archive.git
-    systemd: https://github.com/voxpupuli/puppet-systemd.git
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt'
+    inifile: 'https://github.com/puppetlabs/puppetlabs-inifile'
+    grafana: 'https://github.com/voxpupuli/puppet-grafana'
+    archive: 'https://github.com/voxpupuli/puppet-archive'
+    systemd: 'https://github.com/voxpupuli/puppet-systemd'
     yumrepo:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
       puppet_version: ">= 6.0.0"
-    telegraf:
-      repo: https://github.com/voxpupuli/puppet-telegraf.git
-    facts: https://github.com/puppetlabs/puppetlabs-facts.git
-    puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
-    provision: https://github.com/puppetlabs/provision.git
-    puppet_metrics_collector: https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector.git
-    puppet_conf: "https://github.com/puppetlabs/puppetlabs-puppet_conf"
-    deploy_pe: 'git://github.com/jarretlavallee/puppet-deploy_pe.git'
-    ruby_task_helper: "https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper"
-    cron_core: "git://github.com/puppetlabs/puppetlabs-cron_core"
-    bootstrap: "https://github.com/puppetlabs/puppetlabs-bootstrap"
+    telegraf: 'https://github.com/voxpupuli/puppet-telegraf'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
+    provision: 'https://github.com/puppetlabs/provision'
+    puppet_metrics_collector: 'https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector'
+    puppet_conf: 'https://github.com/puppetlabs/puppetlabs-puppet_conf'
+    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'
+    ruby_task_helper: 'https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper'
+    cron_core: 'https://github.com/puppetlabs/puppetlabs-cron_core'
+    bootstrap: 'https://github.com/puppetlabs/puppetlabs-bootstrap'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.