### PR TITLE
Fix auto deploy workflow and update pdk

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,34 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,7 +25,9 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,31 +9,30 @@ Gemfile:
   optional:
     ":development":
     - gem: github_changelog_generator
-    - gem: puppet_litmus
-      git: https://github.com/puppetlabs/puppet_litmus
-      ref: main
-      condition: Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
   required:
     ':development':
       - gem: 'toml-rb'
+      - gem: 'octokit'
+        version:
+          '= 4.21.0'
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true
 .gitpod.Dockerfile:
-  unmanaged: false
+  unmanaged: true
 .gitpod.yml:
-  unmanaged: false
+  unmanaged: true
 .github/workflows/nightly.yml:
   unmanaged: true
 .github/workflows/auto_release.yml:
-  unmanaged: false
+  unmanaged: true
 .github/workflows/spec.yml:
   checks: 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
   unmanaged: true
 .github/workflows/release.yml:
-  unmanaged: false
+  unmanaged: true
 .github/workflows/pr_test.yml:
-  unmanaged: false
+  unmanaged: true
 .travis.yml:
   delete: true
 Rakefile:

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "toml-rb",                                                 require: false
+  gem "octokit", '= 4.21.0',                                     require: false
   gem "github_changelog_generator",                              require: false
-  gem "puppet_litmus",                                           require: false, git: 'https://github.com/puppetlabs/puppet_litmus', ref: 'main' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -91,14 +91,14 @@ define puppet_metrics_dashboard::profile::puppetdb (
   telegraf::input { "puppetdb_command_queue_${puppetdb_host}":
     plugin_type => 'http',
     options     => [{
-      'data_format'   => 'json',
-      'name_override' => 'httpjson_puppetdb_command_queue',
-      'urls'          => [ "${protocol}://${puppetdb_host}:${port}/status/v1/services?level=debug" ],
+      'data_format'          => 'json',
+      'name_override'        => 'httpjson_puppetdb_command_queue',
+      'urls'                 => [ "${protocol}://${puppetdb_host}:${port}/status/v1/services?level=debug" ],
       # The /status/v1 API will respond with a 503 code if a single
       # sub-service is in an unhealthy state, but will still return metrics.
       'success_status_codes' => [200, 503],
-      'timeout'       => $timeout,
-      'tags'          => {
+      'timeout'              => $timeout,
+      'tags'                 => {
         'server' => $server_name,
       }
       } + $default_options

--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,7 @@
       "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.1.0",
-  "template-url": "pdk-default#2.1.0",
-  "template-ref": "tags/2.1.0-0-ga675ea5"
+  "pdk-version": "2.3.0",
+  "template-url": "pdk-default#2.3.0",
+  "template-ref": "tags/2.3.0-0-g8aaceff"
 }


### PR DESCRIPTION
Prior to the commit the auto deploy work flow no longer worked due to  gem incompatibility with changelog generator.

This commit pins octokit to v 4.21.0 to work around this.

The base PDK template was also updates and some minor liniting issues resolved