### PR TITLE
Update to CODEOWNERS to prevent the second entry overwriting the first

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,4 @@
 # take ownership of parts of the code base that should be reviewed by another
 # team.
 
-*  @puppetlabs/dio
-*  @puppetlabs/support
+*  @puppetlabs/dio @puppetlabs/support


### PR DESCRIPTION
Prior to this change, the second rule just overrode the first