### PR TITLE
(fix) Add privileged and cgroupns arguments to viewer job docker command

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -20,4 +20,4 @@ release_checks:
 viewer:
   provisioner: docker
   images: ['litmusimage/centos:7']
-  vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000", "-v /sys/fs/cgroup:/sys/fs/cgroup:ro"]}'
+  vars: '{docker_run_opts: ["-p 8086:8086", "-p 3000:3000", "--privileged", "--cgroupns=host", "-v /sys/fs/cgroup:/sys/fs/cgroup:rw"]}'


### PR DESCRIPTION
Prior to this PR, the viewer rake job would fail to allow systemd
from starting in the container. This commit changes the docker run
command to add the privileged and cgroupns arguments to enable systemd
to start in the container.